### PR TITLE
KTO-445

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ deploy:
     script: lein deploy
     skip_cleanup: true
     on:
-      branch: KTO-445
+      branch: master
   - provider: script
     script: ./ci-tools/build/upload-image.sh ${ARTIFACT_NAME}
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ deploy:
     script: lein deploy
     skip_cleanup: true
     on:
-      branch: master
+      branch: KTO-445
   - provider: script
     script: ./ci-tools/build/upload-image.sh ${ARTIFACT_NAME}
     on:

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
   "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject kouta-indeksoija-service "0.1.13-SNAPSHOT"
+(defproject kouta-indeksoija-service "0.1.14-SNAPSHOT"
   :description "FIXME: write description"
   :repositories [["releases" {:url "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"
                               :username :env/artifactory_username

--- a/src/kouta_indeksoija_service/indexer/cache/hierarkia.clj
+++ b/src/kouta_indeksoija_service/indexer/cache/hierarkia.clj
@@ -14,12 +14,14 @@
 
 (defn cache-hierarkia
   [oid]
+
   (when-let [hierarkia (get-hierarkia-v4 oid :aktiiviset true :suunnitellut false :lakkautetut false :skipParents false)]
     (let [this (find-from-hierarkia hierarkia oid)]
       (cond
         (koulutustoimija? this) (do-cache hierarkia (vector oid))
         (oppilaitos? this)      (do-cache hierarkia (filter #(not (koulutustoimija? %)) (get-all-oids-flat hierarkia)))
-        :else                   (cache-hierarkia (:oid (find-oppilaitos-from-hierarkia hierarkia)))))))
+        :else                   (when-let [oppilaitos-oid (:oid (find-oppilaitos-from-hierarkia hierarkia))]
+                                  (cache-hierarkia oppilaitos-oid))))))
 
 (defn get-hierarkia
   [oid]

--- a/src/kouta_indeksoija_service/indexer/indexable.clj
+++ b/src/kouta_indeksoija_service/indexer/indexable.clj
@@ -14,16 +14,16 @@
        (log/error e "Indeksoinnissa " oid " tapahtui virhe.")
        nil)))
 
-(defn do-index-all
+(defn- create-docs
   [oids f]
-  (doall (pmap #(eat-and-log-errors % f) oids)))
+  (flatten (doall (pmap #(eat-and-log-errors % f) oids))))
 
 (defn do-index
   [index-name oids f]
   (when-not (empty? oids)
     (log/info (str "Indeksoidaan " (count oids) " indeksiin " index-name))
     (let [start (. System (currentTimeMillis))
-          docs (remove nil? (do-index-all oids f))]
+          docs (remove nil? (create-docs oids f))]
       (upsert-index index-name docs)
       (log/info (str "Indeksointi " index-name " kesti " (- (. System (currentTimeMillis)) start) " ms."))
       docs)))

--- a/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
@@ -9,7 +9,6 @@
             [kouta-indeksoija-service.indexer.indexable :as indexable]
             [kouta-indeksoija-service.indexer.kouta.common :as common]
             [kouta-indeksoija-service.util.tools :refer [->distinct-vec]]
-            [cheshire.core :as cheshire]
             [kouta-indeksoija-service.indexer.tools.tarjoaja :as tarjoaja]))
 
 (def index-name "koulutus-kouta-search")
@@ -26,7 +25,8 @@
          :nimet              (vector (:nimi koulutus))
          :oppilaitosOid      (:oid oppilaitos)
          :onkoTuleva         true
-         :nimi               (:nimi oppilaitos))))
+         :nimi               (:nimi oppilaitos)
+         :metadata           {:koulutustyyppi (koulutustyyppi-for-organisaatio oppilaitos)})))
 
 (defn jarjestaja-hits
   [hierarkia koulutus toteutukset]
@@ -52,7 +52,8 @@
              :metadata           {:tutkintonimikkeetKoodiUrit (tutkintonimikeKoodiUrit koulutus)
                                   :opetusajatKoodiUrit        (:opetusaikaKoodiUrit opetus)
                                   :onkoMaksullinen            (:onkoMaksullinen opetus)
-                                  :maksunMaara                (:maksunMaara opetus)}))))
+                                  :maksunMaara                (:maksunMaara opetus)
+                                  :koulutustyyppi             (koulutustyyppi-for-organisaatio oppilaitos)}))))
 
 (defn tuleva-jarjestaja?
   [hierarkia toteutukset]

--- a/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
@@ -36,7 +36,7 @@
 
         (hit :koulutustyyppi     (:koulutustyyppi koulutus)
              :koulutustyyppiUrit (koulutustyyppiKoodiUrit koulutus)
-             :opetuskieliUrit    (get-in toteutus [:metadata :opetus :opetuskieliKoodiUrit])
+             :opetuskieliUrit    (:opetuskieliKoodiUrit opetus)
              :tarjoajat          (vec (map #(organisaatio-tool/find-from-hierarkia hierarkia %) (:tarjoajat toteutus)))
              :oppilaitos         oppilaitos
              :koulutusalaUrit    (koulutusalaKoodiUrit koulutus)

--- a/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
@@ -7,70 +7,104 @@
             [kouta-indeksoija-service.indexer.tools.general :refer :all]
             [kouta-indeksoija-service.indexer.tools.search :refer :all]
             [kouta-indeksoija-service.indexer.indexable :as indexable]
-            [kouta-indeksoija-service.indexer.kouta.common :as common]))
+            [kouta-indeksoija-service.indexer.kouta.common :as common]
+            [kouta-indeksoija-service.util.tools :refer [->distinct-vec]]
+            [cheshire.core :as cheshire]
+            [kouta-indeksoija-service.indexer.tools.tarjoaja :as tarjoaja]))
 
 (def index-name "koulutus-kouta-search")
 
-(defn get-tarjoaja-and-oppilaitos
-  [oid]
-  (let [hierarkia (cache/get-hierarkia oid)]
-    {:tarjoaja   (organisaatio-tool/find-from-hierarkia hierarkia oid)
-     :oppilaitos (organisaatio-tool/find-oppilaitos-from-hierarkia hierarkia)}))
-
-(defn koulutus-hit
-  [koulutus]
-  (let [organisaatiot (map get-tarjoaja-and-oppilaitos (:tarjoajat koulutus))]
+(defn tuleva-jarjestaja-hit
+  [hierarkia koulutus]
+  (let [oppilaitos (organisaatio-tool/find-oppilaitos-from-hierarkia hierarkia)
+        tarjoajat  (:tarjoajat (tarjoaja/remove-other-tarjoajat-from-entry hierarkia koulutus))]
     (hit :koulutustyyppi     (:koulutustyyppi koulutus)
          :koulutustyyppiUrit (koulutustyyppiKoodiUrit koulutus)
-         :tarjoajat          (vec (map :tarjoaja organisaatiot))
-         :oppilaitokset      (vec (map :oppilaitos organisaatiot))
+         :tarjoajat          (vec (map #(organisaatio-tool/find-from-hierarkia hierarkia %) tarjoajat))
+         :oppilaitos         oppilaitos
          :koulutusalaUrit    (koulutusalaKoodiUrit koulutus)
-         :nimet              (vector (:nimi koulutus)))))
+         :nimet              (vector (:nimi koulutus))
+         :oppilaitosOid      (:oid oppilaitos)
+         :onkoTuleva         true
+         :nimi               (:nimi oppilaitos))))
 
-(defn toteutus-hit
-  [koulutus toteutus]
-  (let [organisaatiot (map get-tarjoaja-and-oppilaitos (:tarjoajat toteutus))]
-    (hit :koulutustyyppi     (:koulutustyyppi koulutus)
-         :koulutustyyppiUrit (koulutustyyppiKoodiUrit koulutus)
-         :opetuskieliUrit    (get-in toteutus [:metadata :opetus :opetuskieliKoodiUrit])
-         :tarjoajat          (vec (map :tarjoaja organisaatiot))
-         :oppilaitokset      (vec (map :oppilaitos organisaatiot))
-         :koulutusalaUrit    (koulutusalaKoodiUrit koulutus)
-         :nimet              (vector (:nimi koulutus) (:nimi toteutus))
-         ;:hakuOnKaynnissa   (->real-hakuajat hakutieto) TODO
-         ;:haut              (:haut hakutieto) TODO
-         :asiasanat          (asiasana->lng-value-map (get-in toteutus [:metadata :asiasanat]))
-         :ammattinimikkeet   (asiasana->lng-value-map (get-in toteutus [:metadata :ammattinimikkeet])))))
+(defn jarjestaja-hits
+  [hierarkia koulutus toteutukset]
+  (let [oppilaitos (organisaatio-tool/find-oppilaitos-from-hierarkia hierarkia)]
+    (for [toteutus (tarjoaja/get-tarjoaja-entries hierarkia toteutukset)
+          :let [opetus (get-in toteutus [:metadata :opetus])]]
 
-(defn- create-base-entry
-  [koulutus]
-  (-> koulutus
-      (select-keys [:oid :nimi :kielivalinta])
-      (assoc :koulutus                (:koulutusKoodiUri koulutus))
-      (assoc :tutkintonimikkeet       (tutkintonimikeKoodiUrit koulutus))
-      (assoc :kuvaus                  (get-in koulutus [:metadata :kuvaus]))
-      (assoc :koulutustyyppi          (:koulutustyyppi koulutus))
-      (assoc :opintojenlaajuus        (opintojenlaajuusKoodiUri koulutus))
-      (assoc :opintojenlaajuusyksikko (opintojenlaajuusyksikkoKoodiUri koulutus))
-      (common/decorate-koodi-uris)))
+        (hit :koulutustyyppi     (:koulutustyyppi koulutus)
+             :koulutustyyppiUrit (koulutustyyppiKoodiUrit koulutus)
+             :opetuskieliUrit    (get-in toteutus [:metadata :opetus :opetuskieliKoodiUrit])
+             :tarjoajat          (vec (map #(organisaatio-tool/find-from-hierarkia hierarkia %) (:tarjoajat toteutus)))
+             :oppilaitos         oppilaitos
+             :koulutusalaUrit    (koulutusalaKoodiUrit koulutus)
+             :nimet              (vector (:nimi koulutus) (:nimi toteutus))
+             ;:hakuOnKaynnissa   (->real-hakuajat hakutieto) TODO
+             ;:haut              (:haut hakutieto) TODO
+             ;:logo              TODO
+             :asiasanat          (asiasana->lng-value-map (get-in toteutus [:metadata :asiasanat]))
+             :ammattinimikkeet   (asiasana->lng-value-map (get-in toteutus [:metadata :ammattinimikkeet]))
+             :toteutusOid        (:oid toteutus)
+             :onkoTuleva         false
+             :nimi               (:nimi oppilaitos)
+             :metadata           {:tutkintonimikkeetKoodiUrit (tutkintonimikeKoodiUrit koulutus)
+                                  :opetusajatKoodiUrit        (:opetusaikaKoodiUrit opetus)
+                                  :onkoMaksullinen            (:onkoMaksullinen opetus)
+                                  :maksunMaara                (:maksunMaara opetus)}))))
+
+(defn tuleva-jarjestaja?
+  [hierarkia toteutukset]
+  (-> (organisaatio-tool/find-oids-from-hierarkia hierarkia (mapcat :tarjoajat toteutukset))
+      (->distinct-vec)
+      (empty?)))
 
 ;TODO
 ; (defn get-toteutuksen-hakutieto
 ;  [hakutiedot t]
 ;  (first (filter (fn [x] (= (:toteutusOid x) (:oid t))) hakutiedot)))
 
+(defn find-distinct-oppilaitos-oids
+  [tarjoajat]
+  (->> tarjoajat
+       (map cache/get-hierarkia)                            ;ei väliä onko koko vai ei
+       (map organisaatio-tool/find-oppilaitos-from-hierarkia)
+       (map :oid)
+       (->distinct-vec)))
+
+(defn assoc-jarjestaja-hits
+  [koulutus]
+  (let [toteutukset (seq (kouta-backend/get-toteutus-list-for-koulutus (:oid koulutus) true))
+        ;hakutiedot (when toteutukset (kouta-backend/get-hakutiedot-for-koulutus oid)) TODO
+        ]
+    (->> (for [hierarkia (map cache/get-hierarkia (find-distinct-oppilaitos-oids (:tarjoajat koulutus)))] ;koko hierarkia
+           (if (tuleva-jarjestaja? hierarkia toteutukset)
+             {:hits [(tuleva-jarjestaja-hit hierarkia koulutus)]}
+             {:hits (jarjestaja-hits hierarkia koulutus toteutukset)}))
+         (apply merge-with concat)
+         (merge koulutus))))
+
+(defn- create-entry
+  [koulutus]
+  (-> koulutus
+     (select-keys [:oid :nimi :kielivalinta])
+     (assoc :koulutus                (:koulutusKoodiUri koulutus))
+     (assoc :tutkintonimikkeet       (tutkintonimikeKoodiUrit koulutus))
+     (assoc :kuvaus                  (get-in koulutus [:metadata :kuvaus]))
+     (assoc :koulutustyyppi          (:koulutustyyppi koulutus))
+     (assoc :opintojenlaajuus        (opintojenlaajuusKoodiUri koulutus))
+     (assoc :opintojenlaajuusyksikko (opintojenlaajuusyksikkoKoodiUri koulutus))
+     (common/decorate-koodi-uris)
+     (assoc :hits (:hits koulutus))))
+
 (defn create-index-entry
   [oid]
   (let [koulutus (kouta-backend/get-koulutus oid)]
     (when (julkaistu? koulutus)
-      (let [toteutukset (seq (kouta-backend/get-toteutus-list-for-koulutus oid true))
-            ;hakutiedot (when toteutukset (kouta-backend/get-hakutiedot-for-koulutus oid)) TODO
-            ]
-        (-> koulutus
-            (create-base-entry)
-            (assoc :hits (if toteutukset
-                           (vec (map #(toteutus-hit koulutus %) toteutukset))
-                           (vector (koulutus-hit koulutus)))))))))
+      (-> koulutus
+          (assoc-jarjestaja-hits)
+          (create-entry)))))
 
 (defn do-index
   [oids]

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
@@ -35,7 +35,7 @@
 
 (defn create-index-entry
   [oid]
-  (let [hierarkia (cache/get-hierarkia oid)]
+  (let [hierarkia (cache/get-hierarkia oid)]                ;koko hierarkia
     (when-let [organisaatio (organisaatio-tool/find-oppilaitos-from-hierarkia hierarkia)]
       (when (organisaatio-tool/indexable? organisaatio)
         (let [oppilaitos-oid (:oid organisaatio)

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos_search.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos_search.clj
@@ -8,9 +8,7 @@
             [kouta-indeksoija-service.util.tools :refer [->distinct-vec]]
             [kouta-indeksoija-service.indexer.indexable :as indexable]
             [kouta-indeksoija-service.indexer.tools.general :refer :all]
-            [cheshire.core :as cheshire]
-            [kouta-indeksoija-service.indexer.tools.search :refer :all]
-            [kouta-indeksoija-service.indexer.tools.tyyppi :refer [oppilaitostyyppi-uri-to-tyyppi]]))
+            [kouta-indeksoija-service.indexer.tools.search :refer :all]))
 
 (def index-name "oppilaitos-kouta-search")
 
@@ -18,17 +16,13 @@
   [oppilaitos tarjoajat]
   (vec (map #(organisaatio-tool/find-from-organisaatio-and-children oppilaitos %) tarjoajat)))
 
-(defn- koulutustyyppi-for-organisaatio
-  [organisaatio]
-  (when-let [oppilaitostyyppi (:oppilaitostyyppi organisaatio)]
-    (oppilaitostyyppi-uri-to-tyyppi oppilaitostyyppi)))
-
 (defn- tutkintonimikkeet-for-osaamisala
   [osaamisalaKoodiUri]
   (list-alakoodi-nimet-with-cache osaamisalaKoodiUri "tutkintonimikkeet"))
 
 (defn- tutkintonimikket-for-toteutus
   [toteutus]
+  ;TODO -> eperusteet
   (when (ammatillinen? toteutus)
     (->> (get-in toteutus [:metadata :osaamisalat :koodiUri])
          (mapcat tutkintonimikkeet-for-osaamisala)
@@ -53,11 +47,11 @@
        :koulutusOid        (:oid koulutus)
        :onkoTuleva         true
        :nimi               (:nimi koulutus)
-       :metadata           {:tutkintonimikkeetKoodiUrit (tutkintonimikeKoodiUrit koulutus)
-                            :opintojenLaajuusKoodiUri (opintojenlaajuusKoodiUri koulutus)
+       :metadata           {:tutkintonimikkeetKoodiUrit      (tutkintonimikeKoodiUrit koulutus)
+                            :opintojenLaajuusKoodiUri        (opintojenlaajuusKoodiUri koulutus)
                             :opintojenLaajuusyksikkoKoodiUri (opintojenlaajuusyksikkoKoodiUri koulutus)
-                            :koulutustyypitKoodiUrit (koulutustyyppiKoodiUrit koulutus)
-                            :koulutusalatKoodiUrit (koulutusalaKoodiUrit koulutus)}))
+                            :koulutustyypitKoodiUrit         (koulutustyyppiKoodiUrit koulutus)
+                            :koulutustyyppi                  (:koulutustyyppi koulutus)}))
 
 (defn toteutus-hit
   [oppilaitos koulutus toteutus]
@@ -76,10 +70,11 @@
          :toteutusOid        (:oid toteutus)
          :nimi               (:nimi toteutus)
          :onkoTuleva         false
-         :metadata           {:tutkintonimikkeet   (tutkintonimikket-for-toteutus toteutus)
+         :metadata           {:tutkintonimikkeet  (tutkintonimikket-for-toteutus toteutus)
                               :opetusajatKoodiUrit (:opetusaikaKoodiUrit opetus)
                               :onkoMaksullinen     (:onkoMaksullinen opetus)
-                              :maksunMaara         (:maksunMaara opetus)})))
+                              :maksunMaara         (:maksunMaara opetus)
+                              :koulutustyyppi      (:koulutustyyppi koulutus)})))
 
 (defn- get-kouta-oppilaitos
   [oid]

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos_search.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos_search.clj
@@ -1,11 +1,14 @@
 (ns kouta-indeksoija-service.indexer.kouta.oppilaitos-search
   (:require [kouta-indeksoija-service.rest.kouta :as kouta-backend]
-            [kouta-indeksoija-service.rest.koodisto :refer [get-koodi-nimi-with-cache]]
+            [kouta-indeksoija-service.rest.koodisto :refer [get-koodi-nimi-with-cache list-alakoodi-nimet-with-cache]]
             [kouta-indeksoija-service.indexer.cache.hierarkia :as cache]
+            [kouta-indeksoija-service.indexer.tools.tarjoaja :as tarjoaja]
             [kouta-indeksoija-service.indexer.tools.organisaatio :as organisaatio-tool]
             [kouta-indeksoija-service.indexer.tools.hakuaika :refer [->real-hakuajat]]
+            [kouta-indeksoija-service.util.tools :refer [->distinct-vec]]
             [kouta-indeksoija-service.indexer.indexable :as indexable]
             [kouta-indeksoija-service.indexer.tools.general :refer :all]
+            [cheshire.core :as cheshire]
             [kouta-indeksoija-service.indexer.tools.search :refer :all]
             [kouta-indeksoija-service.indexer.tools.tyyppi :refer [oppilaitostyyppi-uri-to-tyyppi]]))
 
@@ -20,12 +23,23 @@
   (when-let [oppilaitostyyppi (:oppilaitostyyppi organisaatio)]
     (oppilaitostyyppi-uri-to-tyyppi oppilaitostyyppi)))
 
+(defn- tutkintonimikkeet-for-osaamisala
+  [osaamisalaKoodiUri]
+  (list-alakoodi-nimet-with-cache osaamisalaKoodiUri "tutkintonimikkeet"))
+
+(defn- tutkintonimikket-for-toteutus
+  [toteutus]
+  (when (ammatillinen? toteutus)
+    (->> (get-in toteutus [:metadata :osaamisalat :koodiUri])
+         (mapcat tutkintonimikkeet-for-osaamisala)
+         (->distinct-vec))))
+
 (defn oppilaitos-hit
   [oppilaitos]
   (hit :koulutustyyppi  (koulutustyyppi-for-organisaatio oppilaitos)
        :opetuskieliUrit (:kieletUris oppilaitos)
        :tarjoajat       (vector oppilaitos)
-       :oppilaitokset   (vector oppilaitos)))
+       :oppilaitos      oppilaitos))
 
 (defn koulutus-hit
   [oppilaitos koulutus]
@@ -33,21 +47,39 @@
        :koulutustyyppiUrit (koulutustyyppiKoodiUrit koulutus)
        ;:opetuskieliUrit   (:kieletUris oppilaitos)
        :tarjoajat          (tarjoaja-organisaatiot oppilaitos (:tarjoajat koulutus))
-       :oppilaitokset      (vector oppilaitos)
+       :oppilaitos         oppilaitos
        :koulutusalaUrit    (koulutusalaKoodiUrit koulutus)
-       :nimet              (vector (:nimi koulutus))))
+       :nimet              (vector (:nimi koulutus))
+       :koulutusOid        (:oid koulutus)
+       :onkoTuleva         true
+       :nimi               (:nimi koulutus)
+       :metadata           {:tutkintonimikkeetKoodiUrit (tutkintonimikeKoodiUrit koulutus)
+                            :opintojenLaajuusKoodiUri (opintojenlaajuusKoodiUri koulutus)
+                            :opintojenLaajuusyksikkoKoodiUri (opintojenlaajuusyksikkoKoodiUri koulutus)
+                            :koulutustyypitKoodiUrit (koulutustyyppiKoodiUrit koulutus)
+                            :koulutusalatKoodiUrit (koulutusalaKoodiUrit koulutus)}))
 
 (defn toteutus-hit
   [oppilaitos koulutus toteutus]
-  (hit :koulutustyyppi     (:koulutustyyppi koulutus)
-       :koulutustyyppiUrit (koulutustyyppiKoodiUrit koulutus)
-       :opetuskieliUrit    (get-in toteutus [:metadata :opetus :opetuskieliKoodiUrit])
-       :tarjoajat          (tarjoaja-organisaatiot oppilaitos (:tarjoajat toteutus))
-       :oppilaitokset      (vector oppilaitos)
-       :koulutusalaUrit    (koulutusalaKoodiUrit koulutus)
-       :nimet              (vector (:nimi koulutus) (:nimi toteutus))
-       :asiasanat          (asiasana->lng-value-map (get-in toteutus [:metadata :asiasanat]))
-       :ammattinimikkeet   (asiasana->lng-value-map (get-in toteutus [:metadata :ammattinimikkeet]))))
+  (let [opetus (get-in toteutus [:metadata :opetus])]
+
+    (hit :koulutustyyppi     (:koulutustyyppi koulutus)
+         :koulutustyyppiUrit (koulutustyyppiKoodiUrit koulutus)
+         :opetuskieliUrit    (get-in toteutus [:metadata :opetus :opetuskieliKoodiUrit])
+         :tarjoajat          (tarjoaja-organisaatiot oppilaitos (:tarjoajat toteutus))
+         :oppilaitos         oppilaitos
+         :koulutusalaUrit    (koulutusalaKoodiUrit koulutus)
+         :nimet              (vector (:nimi koulutus) (:nimi toteutus))
+         :asiasanat          (asiasana->lng-value-map (get-in toteutus [:metadata :asiasanat]))
+         :ammattinimikkeet   (asiasana->lng-value-map (get-in toteutus [:metadata :ammattinimikkeet]))
+         :koulutusOid        (:oid koulutus)
+         :toteutusOid        (:oid toteutus)
+         :nimi               (:nimi toteutus)
+         :onkoTuleva         false
+         :metadata           {:tutkintonimikkeet   (tutkintonimikket-for-toteutus toteutus)
+                              :opetusajatKoodiUrit (:opetusaikaKoodiUrit opetus)
+                              :onkoMaksullinen     (:onkoMaksullinen opetus)
+                              :maksunMaara         (:maksunMaara opetus)})))
 
 (defn- get-kouta-oppilaitos
   [oid]
@@ -63,22 +95,14 @@
       (merge (get-kouta-oppilaitos (:oid oppilaitos)))
       (assoc :koulutusohjelmia (count (filter :johtaaTutkintoon koulutukset)))))
 
-(defn- remove-not-allowed-tarjoaja-oids
-  [allowed-tarjoaja-oids entry]
-  (assoc entry :tarjoajat (vec (clojure.set/intersection (set (:tarjoajat entry)) (set allowed-tarjoaja-oids)))))
-
-(defn- filter-and-reduce-entries-by-tarjoajat
-  [allowed-tarjoaja-oids entries]
-  (seq (filter #(not (empty? (:tarjoajat %))) (map #(remove-not-allowed-tarjoaja-oids allowed-tarjoaja-oids %) entries))))
-
 (defn- assoc-paikkakunnat
   [entry]
   (let [paikkakuntaKoodiUrit (vec (distinct (filter #(clojure.string/starts-with? % "kunta") (mapcat :sijainti (:hits entry)))))]
     (assoc entry :paikkakunnat (vec (map get-koodi-nimi-with-cache paikkakuntaKoodiUrit)))))
 
 (defn- create-koulutus-hits
-  [oppilaitos allowed-tarjoaja-oids koulutus]
-  (if-let [toteutukset (filter-and-reduce-entries-by-tarjoajat allowed-tarjoaja-oids (kouta-backend/get-toteutus-list-for-koulutus (:oid koulutus) true))]
+  [oppilaitos hierarkia koulutus]
+  (if-let [toteutukset (tarjoaja/get-tarjoaja-entries hierarkia (kouta-backend/get-toteutus-list-for-koulutus (:oid koulutus) true))]
     (vec (map #(toteutus-hit oppilaitos koulutus %) toteutukset))
     (vector (koulutus-hit oppilaitos koulutus))))
 
@@ -87,9 +111,8 @@
   (let [hierarkia (cache/get-hierarkia oid)]
     (when-let [oppilaitos (organisaatio-tool/find-oppilaitos-from-hierarkia hierarkia)]
       (when (organisaatio-tool/indexable? oppilaitos)
-        (let [allowed-tarjoaja-oids (organisaatio-tool/get-all-oids-flat hierarkia)
-              koulutus-hits (partial create-koulutus-hits oppilaitos allowed-tarjoaja-oids)
-              koulutukset (filter-and-reduce-entries-by-tarjoajat allowed-tarjoaja-oids (kouta-backend/get-koulutukset-by-tarjoaja (:oid oppilaitos)))]
+        (let [koulutus-hits (partial create-koulutus-hits oppilaitos hierarkia)
+              koulutukset (tarjoaja/get-tarjoaja-entries hierarkia (kouta-backend/get-koulutukset-by-tarjoaja (:oid oppilaitos)))]
           (-> oppilaitos
               (create-base-entry koulutukset)
               (assoc :hits (if koulutukset

--- a/src/kouta_indeksoija_service/indexer/tools/search.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/search.clj
@@ -1,32 +1,68 @@
 (ns kouta-indeksoija-service.indexer.tools.search
   (:require [kouta-indeksoija-service.indexer.tools.general :refer [ammatillinen?]]
             [kouta-indeksoija-service.indexer.tools.koodisto :refer :all]
-            [kouta-indeksoija-service.indexer.tools.tyyppi :refer [remove-uri-version]]))
+            [kouta-indeksoija-service.indexer.tools.tyyppi :refer [remove-uri-version]]
+            [kouta-indeksoija-service.indexer.kouta.common :as common]))
 
 (defn- clean-uris
   [uris]
   (vec (map remove-uri-version uris)))
 
 (defn hit
-  [& {:keys [koulutustyyppi koulutustyyppiUrit opetuskieliUrit tarjoajat oppilaitokset koulutusalaUrit nimet asiasanat ammattinimikkeet]
-      :or {koulutustyyppi nil koulutustyyppiUrit [] opetuskieliUrit [] tarjoajat [] oppilaitokset [] koulutusalaUrit [] nimet [] asiasanat [] ammattinimikkeet []}}]
+  [& {:keys [koulutustyyppi
+             koulutustyyppiUrit
+             opetuskieliUrit
+             tarjoajat
+             oppilaitos
+             koulutusalaUrit
+             nimet
+             asiasanat
+             ammattinimikkeet
+             oppilaitosOid
+             koulutusOid
+             toteutusOid
+             onkoTuleva
+             nimi
+             metadata]
+      :or {koulutustyyppi nil
+           koulutustyyppiUrit []
+           opetuskieliUrit []
+           tarjoajat []
+           oppilaitos []
+           koulutusalaUrit []
+           nimet []
+           asiasanat []
+           ammattinimikkeet []
+           oppilaitosOid nil
+           koulutusOid nil
+           toteutusOid nil
+           onkoTuleva nil
+           nimi {}
+           metadata {}}}]
 
   (let [kunnat (remove nil? (distinct (map :kotipaikkaUri tarjoajat)))
         maakunnat (remove nil? (distinct (map #(:koodiUri (maakunta %)) kunnat)))
 
         terms (fn [lng-keyword] (distinct (remove nil? (concat (map lng-keyword nimet) ;HUOM! Älä tee tästä defniä, koska se ei enää ole thread safe!
-                                                               (map #(-> % :nimi lng-keyword) oppilaitokset)
+                                                               (vector (-> oppilaitos :nimi lng-keyword))
                                                                (map #(-> % :nimi lng-keyword) tarjoajat)
                                                                (map lng-keyword asiasanat)
                                                                (map lng-keyword ammattinimikkeet)))))]
 
-      {:koulutustyypit (clean-uris (concat (vector koulutustyyppi) koulutustyyppiUrit))
-       :opetuskielet   (clean-uris opetuskieliUrit)
-       :sijainti       (clean-uris (concat kunnat maakunnat))
-       :koulutusalat   (clean-uris koulutusalaUrit)
-       :terms          {:fi (terms :fi)
-                        :sv (terms :sv)
-                        :en (terms :en)}}))
+    (cond-> {:koulutustyypit (clean-uris (concat (vector koulutustyyppi) koulutustyyppiUrit))
+             :opetuskielet (clean-uris opetuskieliUrit)
+             :sijainti (clean-uris (concat kunnat maakunnat))
+             :koulutusalat (clean-uris koulutusalaUrit)
+             :terms {:fi (terms :fi)
+                     :sv (terms :sv)
+                     :en (terms :en)}
+             :metadata (common/decorate-koodi-uris (merge metadata {:kunnat kunnat}))}
+
+            (not (nil? koulutusOid))   (assoc :koulutusOid koulutusOid)
+            (not (nil? toteutusOid))   (assoc :toteutusOid toteutusOid)
+            (not (nil? oppilaitosOid)) (assoc :oppilaitosOid oppilaitosOid)
+            (not (nil? onkoTuleva))    (assoc :onkoTuleva onkoTuleva)
+            (not (empty? nimi))        (assoc :nimi nimi))))
 
 (defn koulutusalaKoodiUrit
   [koulutus]

--- a/src/kouta_indeksoija_service/indexer/tools/search.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/search.clj
@@ -2,7 +2,8 @@
   (:require [kouta-indeksoija-service.indexer.tools.general :refer [ammatillinen?]]
             [kouta-indeksoija-service.indexer.tools.koodisto :refer :all]
             [kouta-indeksoija-service.indexer.tools.tyyppi :refer [remove-uri-version]]
-            [kouta-indeksoija-service.indexer.kouta.common :as common]))
+            [kouta-indeksoija-service.indexer.kouta.common :as common]
+            [kouta-indeksoija-service.indexer.tools.tyyppi :refer [oppilaitostyyppi-uri-to-tyyppi]]))
 
 (defn- clean-uris
   [uris]
@@ -95,3 +96,8 @@
   (if (ammatillinen? koulutus)
     (some-> koulutus :koulutusKoodiUri (opintojenlaajuusyksikko) :koodiUri)
     (get-in koulutus [:metadata :opintojenLaajuusyksikkoKoodiUri])))
+
+(defn koulutustyyppi-for-organisaatio
+  [organisaatio]
+  (when-let [oppilaitostyyppi (:oppilaitostyyppi organisaatio)]
+    (oppilaitostyyppi-uri-to-tyyppi oppilaitostyyppi)))

--- a/src/kouta_indeksoija_service/indexer/tools/tarjoaja.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/tarjoaja.clj
@@ -1,0 +1,36 @@
+(ns kouta-indeksoija-service.indexer.tools.tarjoaja
+  (:require [kouta-indeksoija-service.indexer.tools.organisaatio :as organisaatio-tool]
+            [kouta-indeksoija-service.util.tools :refer [->distinct-vec]]))
+
+(defn get-tarjoaja-oids-for-organisaatio
+  [hierarkia]
+  (organisaatio-tool/get-all-oids-flat hierarkia))
+
+(defn tarjoajia?
+  [entry]
+  (not (empty? (:tarjoajat entry))))
+
+(defn remove-other-tarjoajat-from-entry-by-oids
+  [oids entry]
+  (assoc entry :tarjoajat (vec (clojure.set/intersection (set (:tarjoajat entry)) (set oids)))))
+
+(defn remove-other-tarjoajat-from-entry
+  [hierarkia entry]
+  (-> (get-tarjoaja-oids-for-organisaatio hierarkia)
+      (remove-other-tarjoajat-from-entry-by-oids entry)))
+
+(defn get-tarjoaja-entries-by-oids
+  [oids entries]
+  (seq (filter tarjoajia? (map #(remove-other-tarjoajat-from-entry-by-oids oids %) entries))))
+
+(defn get-tarjoaja-entries
+  [hierarkia entries]
+  (-> (get-tarjoaja-oids-for-organisaatio hierarkia)
+      (get-tarjoaja-entries-by-oids entries)))
+
+(defn get-tarjoajien-sijainnit
+  [hierarkia entry]
+  (->> (:tarjoajat entry)
+       (organisaatio-tool/find-from-hierarkia hierarkia)
+       (map :kotipaikkaKoodiUri)
+       (->distinct-vec)))

--- a/src/kouta_indeksoija_service/util/tools.clj
+++ b/src/kouta_indeksoija_service/util/tools.clj
@@ -12,3 +12,7 @@
 (defn comma-separated-string->vec
   [s]
   (vec (remove blank? (some-> s (split #",")))))
+
+(defn ->distinct-vec
+  [coll]
+  (vec (distinct (remove nil? coll))))

--- a/test/kouta_indeksoija_service/indexer/kouta_search_index_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_search_index_test.clj
@@ -92,5 +92,6 @@
        (testing "Create correct search item when koulutus has toteutukset"
          (is (nil? (get-doc koulutus/index-name koulutus-oid2)))
          (i/index-koulutus koulutus-oid2)
+         (debug-pretty (get-doc koulutus/index-name koulutus-oid2))
          (compare-json (no-timestamp (json json-path "koulutus-search-item-toteutukset"))
                        (no-timestamp (get-doc koulutus/index-name koulutus-oid2))))))))

--- a/test/kouta_indeksoija_service/indexer/kouta_search_index_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_search_index_test.clj
@@ -70,6 +70,7 @@
      (testing "Create correct search item when oppilaitos has koulutukset and toteutukset"
        (is (nil? (get-doc oppilaitos/index-name oppilaitos-oid2)))
        (i/index-oppilaitos oppilaitos-oid2)
+       (debug-pretty (get-doc oppilaitos/index-name oppilaitos-oid2))
        (compare-json (no-timestamp (json json-path "oppilaitos-search-item-koulutus-and-toteutukset"))
                      (no-timestamp (get-doc oppilaitos/index-name oppilaitos-oid2))))))
 

--- a/test/resources/search/koulutus-search-item-no-toteutukset.json
+++ b/test/resources/search/koulutus-search-item-no-toteutukset.json
@@ -51,6 +51,21 @@
       "fi" : [ "Oppilaitos fi 1.2.246.562.10.77777777799", "Autoalan perustutkinto 0 fi", "Toimipiste fi 1.2.246.562.10.777777777992" ],
       "sv" : [ "Oppilaitos sv 1.2.246.562.10.77777777799" ,"Autoalan perustutkinto 0 sv", "Toimipiste sv 1.2.246.562.10.777777777992" ],
       "en" : [ ]
+    },
+    "onkoTuleva" : true,
+    "oppilaitosOid" : "1.2.246.562.10.77777777799",
+    "nimi" : {
+      "fi" : "Oppilaitos fi 1.2.246.562.10.77777777799",
+      "sv" : "Oppilaitos sv 1.2.246.562.10.77777777799"
+    },
+    "metadata" : {
+      "kunnat" : [ {
+        "koodiUri" : "kunta_091",
+        "nimi" : {
+          "fi" : "kunta_091 nimi fi",
+          "sv" : "kunta_091 nimi sv"
+        }
+      } ]
     }
   } ],
   "timestamp" : 1571294237902

--- a/test/resources/search/koulutus-search-item-no-toteutukset.json
+++ b/test/resources/search/koulutus-search-item-no-toteutukset.json
@@ -65,7 +65,8 @@
           "fi" : "kunta_091 nimi fi",
           "sv" : "kunta_091 nimi sv"
         }
-      } ]
+      } ],
+      "koulutustyyppi" : "yo"
     }
   } ],
   "timestamp" : 1571294237902

--- a/test/resources/search/koulutus-search-item-toteutukset.json
+++ b/test/resources/search/koulutus-search-item-toteutukset.json
@@ -87,7 +87,8 @@
           "fi" : "kunta_091 nimi fi",
           "sv" : "kunta_091 nimi sv"
         }
-      } ]
+      } ],
+      "koulutustyyppi" : "yo"
     }
   }, {
     "koulutustyypit" : ["amm", "koulutustyyppi_01", "koulutustyyppi_02"],
@@ -135,7 +136,8 @@
           "fi" : "kunta_091 nimi fi",
           "sv" : "kunta_091 nimi sv"
         }
-      } ]
+      } ],
+      "koulutustyyppi" : "yo"
     }
   } ],
   "timestamp" : 1571294237566

--- a/test/resources/search/koulutus-search-item-toteutukset.json
+++ b/test/resources/search/koulutus-search-item-toteutukset.json
@@ -51,6 +51,43 @@
       "fi" : [ "Hevosalan perustutkinto 0 fi" ,"Hevostoteutus 1 fi", "Oppilaitos fi 1.2.246.562.10.77777777799", "Toimipiste fi 1.2.246.562.10.777777777991", "Toimipiste fi 1.2.246.562.10.777777777993", "robotiikka", "robottiautomatiikka", "musiikkioppilaitokset", "hevoset", "psykologia", "automaatioinsinööri", "koneinsinööri", "muusikko", "psykologi", "hevonen" ],
       "sv" : [ "Hevosalan perustutkinto 0 sv" ,"Hevostoteutus 1 sv", "Oppilaitos sv 1.2.246.562.10.77777777799", "Toimipiste sv 1.2.246.562.10.777777777991", "Toimipiste sv 1.2.246.562.10.777777777993", "hepparna", "heppa" ],
       "en" : [ "horses", "horse" ]
+    },
+    "toteutusOid" : "1.2.246.562.17.00000000000000000099",
+    "nimi" : {
+      "fi" : "Oppilaitos fi 1.2.246.562.10.77777777799",
+      "sv" : "Oppilaitos sv 1.2.246.562.10.77777777799"
+    },
+    "onkoTuleva" : false,
+    "metadata" : {
+      "tutkintonimikkeet" : [ {
+        "koodiUri" : "tutkintonimikkeet_01",
+        "nimi" : {
+          "fi" : "tutkintonimikkeet_01 nimi fi",
+          "sv" : "tutkintonimikkeet_01 nimi sv"
+        }
+      }, {
+        "koodiUri" : "tutkintonimikkeet_02",
+        "nimi" : {
+          "fi" : "tutkintonimikkeet_02 nimi fi",
+          "sv" : "tutkintonimikkeet_02 nimi sv"
+        }
+      } ],
+      "opetusajat" : [ {
+        "koodiUri" : "opetusaikakk_1#1",
+        "nimi" : {
+          "fi" : "opetusaikakk_1#1 nimi fi",
+          "sv" : "opetusaikakk_1#1 nimi sv"
+        }
+      } ],
+      "onkoMaksullinen" : true,
+      "maksunMaara" : 200.5,
+      "kunnat" : [ {
+        "koodiUri" : "kunta_091",
+        "nimi" : {
+          "fi" : "kunta_091 nimi fi",
+          "sv" : "kunta_091 nimi sv"
+        }
+      } ]
     }
   }, {
     "koulutustyypit" : ["amm", "koulutustyyppi_01", "koulutustyyppi_02"],
@@ -62,6 +99,43 @@
       "fi" : [ "Hevosalan perustutkinto 0 fi", "Hevostoteutus 2 fi", "Oppilaitos fi 1.2.246.562.10.77777777799", "Toimipiste fi 1.2.246.562.10.777777777991", "robotiikka", "robottiautomatiikka", "insinööri", "koneinsinööri" ],
       "sv" : [ "Hevosalan perustutkinto 0 sv", "Hevostoteutus 2 sv", "Oppilaitos sv 1.2.246.562.10.77777777799", "Toimipiste sv 1.2.246.562.10.777777777991" ],
       "en" : [ ]
+    },
+    "toteutusOid" : "1.2.246.562.17.00000000000000000098",
+    "nimi" : {
+      "fi" : "Oppilaitos fi 1.2.246.562.10.77777777799",
+      "sv" : "Oppilaitos sv 1.2.246.562.10.77777777799"
+    },
+    "onkoTuleva" : false,
+    "metadata" : {
+      "tutkintonimikkeet" : [ {
+        "koodiUri" : "tutkintonimikkeet_01",
+        "nimi" : {
+          "fi" : "tutkintonimikkeet_01 nimi fi",
+          "sv" : "tutkintonimikkeet_01 nimi sv"
+        }
+      }, {
+        "koodiUri" : "tutkintonimikkeet_02",
+        "nimi" : {
+          "fi" : "tutkintonimikkeet_02 nimi fi",
+          "sv" : "tutkintonimikkeet_02 nimi sv"
+        }
+      } ],
+      "opetusajat" : [ {
+        "koodiUri" : "opetusaikakk_1#1",
+        "nimi" : {
+          "fi" : "opetusaikakk_1#1 nimi fi",
+          "sv" : "opetusaikakk_1#1 nimi sv"
+        }
+      } ],
+      "onkoMaksullinen" : true,
+      "maksunMaara" : 200.5,
+      "kunnat" : [ {
+        "koodiUri" : "kunta_091",
+        "nimi" : {
+          "fi" : "kunta_091 nimi fi",
+          "sv" : "kunta_091 nimi sv"
+        }
+      } ]
     }
   } ],
   "timestamp" : 1571294237566

--- a/test/resources/search/oppilaitos-search-item-koulutus-and-toteutukset.json
+++ b/test/resources/search/oppilaitos-search-item-koulutus-and-toteutukset.json
@@ -42,6 +42,7 @@
           "sv" : "kunta_091 nimi sv"
         }
       } ],
+      "koulutustyyppi" : "amm",
       "tutkintonimikkeet" : [ {
         "koodiUri" : "tutkintonimikkeet_01",
         "nimi" : {
@@ -81,31 +82,6 @@
           "fi" : "koulutustyyppi_02 nimi fi",
           "sv" : "koulutustyyppi_02 nimi sv"
         }
-      } ],
-      "koulutusalat" : [ {
-        "koodiUri" : "kansallinenkoulutusluokitus2016koulutusalataso1_01",
-        "nimi" : {
-          "fi" : "kansallinenkoulutusluokitus2016koulutusalataso1_01 nimi fi",
-          "sv" : "kansallinenkoulutusluokitus2016koulutusalataso1_01 nimi sv"
-        }
-      }, {
-        "koodiUri" : "kansallinenkoulutusluokitus2016koulutusalataso1_02",
-        "nimi" : {
-          "fi" : "kansallinenkoulutusluokitus2016koulutusalataso1_02 nimi fi",
-          "sv" : "kansallinenkoulutusluokitus2016koulutusalataso1_02 nimi sv"
-        }
-      }, {
-        "koodiUri" : "kansallinenkoulutusluokitus2016koulutusalataso2_01",
-        "nimi" : {
-          "fi" : "kansallinenkoulutusluokitus2016koulutusalataso2_01 nimi fi",
-          "sv" : "kansallinenkoulutusluokitus2016koulutusalataso2_01 nimi sv"
-        }
-      }, {
-        "koodiUri" : "kansallinenkoulutusluokitus2016koulutusalataso2_02",
-        "nimi" : {
-          "fi" : "kansallinenkoulutusluokitus2016koulutusalataso2_02 nimi fi",
-          "sv" : "kansallinenkoulutusluokitus2016koulutusalataso2_02 nimi sv"
-        }
       } ]
     }
   }, {
@@ -142,6 +118,7 @@
           "sv" : "opetusaikakk_1#1 nimi sv"
         }
       } ],
+      "koulutustyyppi" : "amm",
       "onkoMaksullinen" : true,
       "maksunMaara" : 200.5
     }
@@ -179,6 +156,7 @@
           "sv" : "opetusaikakk_1#1 nimi sv"
         }
       } ],
+      "koulutustyyppi" : "amm",
       "onkoMaksullinen" : true,
       "maksunMaara" : 200.5
     }

--- a/test/resources/search/oppilaitos-search-item-koulutus-and-toteutukset.json
+++ b/test/resources/search/oppilaitos-search-item-koulutus-and-toteutukset.json
@@ -27,6 +27,86 @@
       "fi" : [ "Oppilaitos fi 1.2.246.562.10.77777777799", "Autoalan perustutkinto 0 fi", "Toimipiste fi 1.2.246.562.10.777777777992" ],
       "sv" : [ "Oppilaitos sv 1.2.246.562.10.77777777799", "Autoalan perustutkinto 0 sv", "Toimipiste sv 1.2.246.562.10.777777777992" ],
       "en" : [ ]
+    },
+    "koulutusOid" : "1.2.246.562.13.00000000000000000099",
+    "nimi" : {
+      "fi" : "Autoalan perustutkinto 0 fi",
+      "sv" : "Autoalan perustutkinto 0 sv"
+    },
+    "onkoTuleva" : true,
+    "metadata" : {
+      "kunnat" : [ {
+        "koodiUri" : "kunta_091",
+        "nimi" : {
+          "fi" : "kunta_091 nimi fi",
+          "sv" : "kunta_091 nimi sv"
+        }
+      } ],
+      "tutkintonimikkeet" : [ {
+        "koodiUri" : "tutkintonimikkeet_01",
+        "nimi" : {
+          "fi" : "tutkintonimikkeet_01 nimi fi",
+          "sv" : "tutkintonimikkeet_01 nimi sv"
+        }
+      }, {
+        "koodiUri" : "tutkintonimikkeet_02",
+        "nimi" : {
+          "fi" : "tutkintonimikkeet_02 nimi fi",
+          "sv" : "tutkintonimikkeet_02 nimi sv"
+        }
+      } ],
+      "opintojenLaajuus" : {
+        "koodiUri" : "opintojenlaajuus_01",
+        "nimi" : {
+          "fi" : "opintojenlaajuus_01 nimi fi",
+          "sv" : "opintojenlaajuus_01 nimi sv"
+        }
+      },
+      "opintojenLaajuusyksikko" : {
+        "koodiUri" : "opintojenlaajuusyksikko_01",
+        "nimi" : {
+          "fi" : "opintojenlaajuusyksikko_01 nimi fi",
+          "sv" : "opintojenlaajuusyksikko_01 nimi sv"
+        }
+      },
+      "koulutustyypit" : [ {
+        "koodiUri" : "koulutustyyppi_01",
+        "nimi" : {
+          "fi" : "koulutustyyppi_01 nimi fi",
+          "sv" : "koulutustyyppi_01 nimi sv"
+        }
+      }, {
+        "koodiUri" : "koulutustyyppi_02",
+        "nimi" : {
+          "fi" : "koulutustyyppi_02 nimi fi",
+          "sv" : "koulutustyyppi_02 nimi sv"
+        }
+      } ],
+      "koulutusalat" : [ {
+        "koodiUri" : "kansallinenkoulutusluokitus2016koulutusalataso1_01",
+        "nimi" : {
+          "fi" : "kansallinenkoulutusluokitus2016koulutusalataso1_01 nimi fi",
+          "sv" : "kansallinenkoulutusluokitus2016koulutusalataso1_01 nimi sv"
+        }
+      }, {
+        "koodiUri" : "kansallinenkoulutusluokitus2016koulutusalataso1_02",
+        "nimi" : {
+          "fi" : "kansallinenkoulutusluokitus2016koulutusalataso1_02 nimi fi",
+          "sv" : "kansallinenkoulutusluokitus2016koulutusalataso1_02 nimi sv"
+        }
+      }, {
+        "koodiUri" : "kansallinenkoulutusluokitus2016koulutusalataso2_01",
+        "nimi" : {
+          "fi" : "kansallinenkoulutusluokitus2016koulutusalataso2_01 nimi fi",
+          "sv" : "kansallinenkoulutusluokitus2016koulutusalataso2_01 nimi sv"
+        }
+      }, {
+        "koodiUri" : "kansallinenkoulutusluokitus2016koulutusalataso2_02",
+        "nimi" : {
+          "fi" : "kansallinenkoulutusluokitus2016koulutusalataso2_02 nimi fi",
+          "sv" : "kansallinenkoulutusluokitus2016koulutusalataso2_02 nimi sv"
+        }
+      } ]
     }
   }, {
     "koulutustyypit" : ["amm", "koulutustyyppi_01", "koulutustyyppi_02"],
@@ -38,6 +118,32 @@
       "fi" : [ "Oppilaitos fi 1.2.246.562.10.77777777799", "Hevosalan perustutkinto 0 fi" ,"Hevostoteutus 1 fi", "Toimipiste fi 1.2.246.562.10.777777777993", "Toimipiste fi 1.2.246.562.10.777777777991", "robotiikka", "robottiautomatiikka", "musiikkioppilaitokset", "hevoset", "psykologia", "automaatioinsinööri", "koneinsinööri", "muusikko", "psykologi", "hevonen" ],
       "sv" : [ "Oppilaitos sv 1.2.246.562.10.77777777799", "Hevosalan perustutkinto 0 sv" ,"Hevostoteutus 1 sv", "Toimipiste sv 1.2.246.562.10.777777777993", "Toimipiste sv 1.2.246.562.10.777777777991", "hepparna", "heppa" ],
       "en" : [ "horses", "horse" ]
+    },
+    "koulutusOid" : "1.2.246.562.13.00000000000000000098",
+    "toteutusOid" : "1.2.246.562.17.00000000000000000099",
+    "nimi" : {
+      "fi" : "Hevostoteutus 1 fi",
+      "sv" : "Hevostoteutus 1 sv"
+    },
+    "onkoTuleva" : false,
+    "metadata" : {
+      "kunnat" : [ {
+        "koodiUri" : "kunta_091",
+        "nimi" : {
+          "fi" : "kunta_091 nimi fi",
+          "sv" : "kunta_091 nimi sv"
+        }
+      } ],
+      "tutkintonimikkeet" : null,
+      "opetusajat" : [ {
+        "koodiUri" : "opetusaikakk_1#1",
+        "nimi" : {
+          "fi" : "opetusaikakk_1#1 nimi fi",
+          "sv" : "opetusaikakk_1#1 nimi sv"
+        }
+      } ],
+      "onkoMaksullinen" : true,
+      "maksunMaara" : 200.5
     }
   }, {
     "koulutustyypit" : ["amm", "koulutustyyppi_01", "koulutustyyppi_02"],
@@ -49,6 +155,32 @@
       "fi" : [ "Oppilaitos fi 1.2.246.562.10.77777777799", "Hevosalan perustutkinto 0 fi", "Hevostoteutus 2 fi", "Toimipiste fi 1.2.246.562.10.777777777991", "robotiikka", "robottiautomatiikka", "insinööri", "koneinsinööri" ],
       "sv" : [ "Oppilaitos sv 1.2.246.562.10.77777777799", "Hevosalan perustutkinto 0 sv", "Hevostoteutus 2 sv", "Toimipiste sv 1.2.246.562.10.777777777991" ],
       "en" : [ ]
+    },
+    "koulutusOid" : "1.2.246.562.13.00000000000000000098",
+    "toteutusOid" : "1.2.246.562.17.00000000000000000098",
+    "nimi" : {
+      "fi" : "Hevostoteutus 2 fi",
+      "sv" : "Hevostoteutus 2 sv"
+    },
+    "onkoTuleva" : false,
+    "metadata" : {
+      "kunnat" : [ {
+        "koodiUri" : "kunta_091",
+        "nimi" : {
+          "fi" : "kunta_091 nimi fi",
+          "sv" : "kunta_091 nimi sv"
+        }
+      } ],
+      "tutkintonimikkeet" : null,
+      "opetusajat" : [ {
+        "koodiUri" : "opetusaikakk_1#1",
+        "nimi" : {
+          "fi" : "opetusaikakk_1#1 nimi fi",
+          "sv" : "opetusaikakk_1#1 nimi sv"
+        }
+      } ],
+      "onkoMaksullinen" : true,
+      "maksunMaara" : 200.5
     }
   } ],
   "timestamp" : 1570709741918

--- a/test/resources/search/oppilaitos-search-item-no-koulutukset.json
+++ b/test/resources/search/oppilaitos-search-item-no-koulutukset.json
@@ -26,6 +26,15 @@
       "fi" : [ "Oppilaitos fi 1.2.246.562.10.10101010199" ],
       "sv" : [ "Oppilaitos sv 1.2.246.562.10.10101010199" ],
       "en" : [ ]
+    },
+    "metadata" : {
+      "kunnat" : [ {
+        "koodiUri" : "kunta_091",
+        "nimi" : {
+          "fi" : "kunta_091 nimi fi",
+          "sv" : "kunta_091 nimi sv"
+        }
+      } ]
     }
   } ],
   "timestamp" : 1570702371459


### PR DESCRIPTION
Muutettu hakuindeksien hittien generointia ja lisätty niihin tietoa, jotta niitä voidaan käyttää koulutuksen järjestäjien ja oppilaitoksen tarjonnan hakemiseen.

- Osa tiedoista (lähinnä tutkintonimikkeet) on vielä puutteellisia, koska niille on oma tiketti KTO-497