### PR TITLE
Kto 984

### DIFF
--- a/src/kouta_indeksoija_service/indexer/kouta/koulutus.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/koulutus.clj
@@ -21,7 +21,7 @@
         (assoc-in [:metadata :tutkintonimike]          (->distinct-vec (map (fn [x] {:koodiUri (:tutkintonimikeUri x) :nimi (:nimi x)}) (:tutkintonimikkeet eperuste))))
         (assoc-in [:metadata :opintojenLaajuus]        (:opintojenLaajuus eperuste))
         (assoc-in [:metadata :opintojenLaajuusyksikko] (:opintojenLaajuusyksikko eperuste))
-        (assoc-in [:metadata :koulutusalat]            (koulutusalat-taso1 koulutusKoodi)))))
+        (assoc-in [:metadata :koulutusala]            (koulutusalat-taso1 koulutusKoodi)))))
 
 (defn- get-enriched-tutkinnon-osat
   [tutkinnon-osat]
@@ -39,7 +39,7 @@
   [koulutus]
   (let [tutkinnon-osat (get-in koulutus [:metadata :tutkinnonOsat])]
     (assoc-in koulutus [:metadata :tutkinnonOsat] (get-enriched-tutkinnon-osat tutkinnon-osat))
-    (assoc-in koulutus [:metadata :koulutusalat] (->> tutkinnon-osat
+    (assoc-in koulutus [:metadata :koulutusala] (->> tutkinnon-osat
                                                      (map #(get-in % [:koulutus :koodiUri]))
                                                      (mapcat #(koulutusalat-taso1 %))))))
 
@@ -60,7 +60,7 @@
         (assoc-in [:metadata :opintojenLaajuus] (:opintojenLaajuus osaamisala))
         (assoc-in [:metadata :opintojenLaajuusyksikko] (:opintojenLaajuusyksikko eperuste))
         (assoc-in [:metadata :opintojenLaajuusNumero] (:opintojenLaajuusNumero osaamisala))
-        (assoc-in [:metadata :koulutusalat] (koulutusalat-taso1 koulutusKoodi)))))
+        (assoc-in [:metadata :koulutusala] (koulutusalat-taso1 koulutusKoodi)))))
 
 (defn- enrich-metadata
   [koulutus]

--- a/test/kouta_indeksoija_service/indexer/kouta_koulutus_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_koulutus_test.clj
@@ -78,7 +78,7 @@
        (check-all-nil)
        (i/index-koulutukset [koulutus-oid])
        (let [koulutus (get-doc koulutus/index-name koulutus-oid)
-             koulutusalat (get-in koulutus [:metadata :koulutusalat])]
+             koulutusalat (get-in koulutus [:metadata :koulutusala])]
          (is (= (count koulutusalat) 2))
          (is (first koulutusalat) "joku koulutusala1")
          (is (last koulutusalat) "joku koulutusala2"))))))
@@ -91,6 +91,6 @@
        (check-all-nil)
        (i/index-koulutukset [koulutus-oid])
        (let [koulutus (get-doc koulutus/index-name koulutus-oid)
-             koulutusalat (get-in koulutus [:metadata :koulutusalat])]
+             koulutusalat (get-in koulutus [:metadata :koulutusala])]
          (is (= (count koulutusalat) 1))
          (is (first koulutusalat) "osaamisalan koulutusala"))))))

--- a/test/resources/kouta/kouta-koulutus-result.json
+++ b/test/resources/kouta/kouta-koulutus-result.json
@@ -236,7 +236,7 @@
         }
       }
     ],
-    "koulutusalat": [
+    "koulutusala": [
       {
         "koodiUri": "kansallinenkoulutusluokitus2016koulutusalataso1_01",
         "nimi": {


### PR DESCRIPTION
Rename koulutusala -> koulutusalat. Palautettu alkuperäiseen muotoon koska aiheutti liikaa ongelmia konfo-backendin external api skeeman kanssa