### PR TITLE
KTO-932: Koutan käännöstiedoton lähettäminen json/save-rajapinnan kautta + muita parannuksia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dev_resources/config.edn
 .localstack
 pom.xml
 .eastwood
+.lsp
+.calva
+.clj-kondo

--- a/src/kouta_indeksoija_service/api.clj
+++ b/src/kouta_indeksoija_service/api.clj
@@ -318,12 +318,6 @@
          :body [body (describe schema/Any "Avain-arvo-muotoiset käännökset")]
          (ok (lokalisointi-service/->json body)))
 
-       (POST "/lokalisointi/key-value-pairs/save" []
-         :summary "Tallentaa avain-arvo-parit lokalisointi-palveluun"
-         :query-params [lng :- String]
-         :body [body (describe schema/Any "Käännökset avain-arvo-pareina")]
-         (ok (lokalisointi-service/save-translation-keys-to-localisation-service "kouta" lng body)))
-
        (POST "/lokalisointi/json/konfo/save" []
          :summary "Tallentaa konfo-ui:n käännöstiedoston (translation.json) lokalisointi-palveluun. Ei ylikirjoita olemassaolevia käännösavaimia."
          :query-params [lng :- String]

--- a/src/kouta_indeksoija_service/api.clj
+++ b/src/kouta_indeksoija_service/api.clj
@@ -319,16 +319,22 @@
          (ok (lokalisointi-service/->json body)))
 
        (POST "/lokalisointi/key-value-pairs/save" []
-         :summary "Tallentaa avain-arvo-parit lokalisointiopalveluun"
+         :summary "Tallentaa avain-arvo-parit lokalisointi-palveluun"
          :query-params [lng :- String]
          :body [body (describe schema/Any "Käännökset avain-arvo-pareina")]
-         (ok (lokalisointi-service/save-translation-keys-to-localisation-service lng body)))
+         (ok (lokalisointi-service/save-translation-keys-to-localisation-service "kouta" lng body)))
 
-       (POST "/lokalisointi/json/save" []
-         :summary "Tallentaa jsonin (translation.json) lokalisointiopalveluun"
+       (POST "/lokalisointi/json/konfo/save" []
+         :summary "Tallentaa konfo-ui:n käännöstiedoston (translation.json) lokalisointi-palveluun. Ei ylikirjoita olemassaolevia käännösavaimia."
          :query-params [lng :- String]
-         :body [body (describe schema/Any "JSON-muotoiset käännökset (translation.json)")]
-         (ok (lokalisointi-service/save-translation-json-to-localisation-service lng body))))
+         :body [body (describe schema/Any "JSON-muotoiset käännökset")]
+         (ok (lokalisointi-service/save-translation-json-to-localisation-service "konfo" lng body)))
+
+       (POST "/lokalisointi/json/kouta/save" []
+         :summary "Tallentaa kouta-ui:n käännöstiedoston json-muodossa lokalisointi-palveluun. Ei ylikirjoita olemassaolevia käännösavaimia."
+         :query-params [lng :- String]
+         :body [body (describe schema/Any "JSON-muotoiset käännökset")]
+         (ok (lokalisointi-service/save-translation-json-to-localisation-service "kouta" lng body))))
 
      (context "/jobs" []
        :tags ["jobs"]

--- a/src/kouta_indeksoija_service/lokalisointi/service.clj
+++ b/src/kouta_indeksoija_service/lokalisointi/service.clj
@@ -12,12 +12,12 @@
   (util/key-value-pairs->nested-json translation-keys))
 
 (defn save-translation-keys-to-localisation-service
-  [lng key-value-pairs]
+  [category lng key-value-pairs]
   (doseq [[k v] key-value-pairs]
-    (lokalisointi-service/post lng (name k) v)))
+    (lokalisointi-service/post category lng (name k) v)))
 
 (defn save-translation-json-to-localisation-service
-  [lng json]
+  [category lng json]
   (->> json
        (->translation-keys)
-       (save-translation-keys-to-localisation-service lng)))
+       (save-translation-keys-to-localisation-service category lng)))

--- a/src/kouta_indeksoija_service/rest/lokalisointi.clj
+++ b/src/kouta_indeksoija_service/rest/lokalisointi.clj
@@ -1,7 +1,7 @@
 (ns kouta-indeksoija-service.rest.lokalisointi
   (:require [kouta-indeksoija-service.util.urls :refer [resolve-url]]
             [kouta-indeksoija-service.rest.util :refer [get->json-body]]
-            [kouta-indeksoija-service.rest.cas.session :refer [ init-session cas-authenticated-request-as-json]]
+            [kouta-indeksoija-service.rest.cas.session :refer [init-session cas-authenticated-request-as-json]]
             [cheshire.core :as cheshire]
             [kouta-indeksoija-service.util.time :refer :all]))
 
@@ -12,8 +12,8 @@
   (get->json-body (resolve-url :lokalisointi.v1.localisation-category-locale "konfo" lng)))
 
 (defn- ->post-request
-  [lng key value]
-  {:body (cheshire/generate-string {:category "konfo"
+  [category lng key value]
+  {:body (cheshire/generate-string {:category category
                                     :key key
                                     :value value
                                     :locale lng})
@@ -21,5 +21,5 @@
    :force-redirects true})
 
 (defn post
-  [lng key value]
-  (cas-authenticated-request-as-json cas-session :post (resolve-url :lokalisointi.v1.localisation) (->post-request lng key value)))
+  [category lng key value]
+  (cas-authenticated-request-as-json cas-session :post (resolve-url :lokalisointi.v1.localisation) (->post-request category lng key value)))

--- a/test/kouta_indeksoija_service/indexer/lokalisointi_indexer_test.clj
+++ b/test/kouta_indeksoija_service/indexer/lokalisointi_indexer_test.clj
@@ -17,7 +17,7 @@
   []
   (with-redefs [kouta-indeksoija-service.rest.cas.session/cas-authenticated-request-as-json
                 (fn [x y z req] (swap! lokalisointi-service conj (cheshire/parse-string (:body req) true)))]
-    (service/save-translation-json-to-localisation-service "fi" translation-json)))
+    (service/save-translation-json-to-localisation-service "konfo" "fi" translation-json)))
 
 (use-fixtures :once (fn [test]
                       (store-traslation-json-fixture)

--- a/test/kouta_indeksoija_service/lokalisointi/lokalisointi_test.clj
+++ b/test/kouta_indeksoija_service/lokalisointi/lokalisointi_test.clj
@@ -47,10 +47,10 @@
 
     (testing "Lokalisointi-service should post json to lokalisation service"
       (reset! sent [])
-      (service/save-translation-json-to-localisation-service "fi" translation-json)
+      (service/save-translation-json-to-localisation-service "konfo" "fi" translation-json)
       (is (= (sort comp lokalisation) (sort comp @sent))))
 
     (testing "Lokalisointi-service should post translation keys to lokalisation service"
       (reset! sent [])
-      (service/save-translation-keys-to-localisation-service "fi" key-value-pairs)
+      (service/save-translation-keys-to-localisation-service "konfo" "fi" key-value-pairs)
       (is (= (sort comp lokalisation) (sort comp @sent))))))

--- a/test/resources/kouta/kouta-hakukohde-result.json
+++ b/test/resources/kouta/kouta-hakukohde-result.json
@@ -19,17 +19,17 @@
   },
   "pohjakoulutusvaatimus": [
     {
-      "koodiUri": "pohjakoulutusvaatimustoinenaste_01#2",
+      "koodiUri": "pohjakoulutusvaatimuskouta_104#1",
       "nimi": {
-        "fi": "pohjakoulutusvaatimustoinenaste_01#2 nimi fi",
-        "sv": "pohjakoulutusvaatimustoinenaste_01#2 nimi sv"
+        "fi": "pohjakoulutusvaatimuskouta_104#1 nimi fi",
+        "sv": "pohjakoulutusvaatimuskouta_104#1 nimi sv"
       }
     },
     {
-      "koodiUri": "pohjakoulutusvaatimustoinenaste_02#2",
+      "koodiUri": "pohjakoulutusvaatimuskouta_109#1",
       "nimi": {
-        "fi": "pohjakoulutusvaatimustoinenaste_02#2 nimi fi",
-        "sv": "pohjakoulutusvaatimustoinenaste_02#2 nimi sv"
+        "fi": "pohjakoulutusvaatimuskouta_109#1 nimi fi",
+        "sv": "pohjakoulutusvaatimuskouta_109#1 nimi sv"
       }
     }
   ],

--- a/test/resources/kouta/kouta-toteutus-result.json
+++ b/test/resources/kouta/kouta-toteutus-result.json
@@ -93,17 +93,17 @@
           },
           "pohjakoulutusvaatimus": [
             {
-              "koodiUri": "pohjakoulutusvaatimustoinenaste_01#2",
+              "koodiUri": "pohjakoulutusvaatimuskouta_104#1",
               "nimi": {
-                "fi": "pohjakoulutusvaatimustoinenaste_01#2 nimi fi",
-                "sv": "pohjakoulutusvaatimustoinenaste_01#2 nimi sv"
+                "fi": "pohjakoulutusvaatimuskouta_104#1 nimi fi",
+                "sv": "pohjakoulutusvaatimuskouta_104#1 nimi sv"
               }
             },
             {
-              "koodiUri": "pohjakoulutusvaatimustoinenaste_02#2",
+              "koodiUri": "pohjakoulutusvaatimuskouta_109#1",
               "nimi": {
-                "fi": "pohjakoulutusvaatimustoinenaste_02#2 nimi fi",
-                "sv": "pohjakoulutusvaatimustoinenaste_02#2 nimi sv"
+                "fi": "pohjakoulutusvaatimuskouta_109#1 nimi fi",
+                "sv": "pohjakoulutusvaatimuskouta_109#1 nimi sv"
               }
             }
           ],


### PR DESCRIPTION
- Eriytetty `/admin/lokalisointi/json/save`-rajapinta kahteen erilliseen rajapintaan koutalle ja konfolle.
- Päivitetty testit uuden pohjakoulutusvaatimus-koodiston mukaiseksi