### PR TITLE
Kto 1060 indeksoinnin muutos

### DIFF
--- a/src/kouta_indeksoija_service/indexer/indexer.clj
+++ b/src/kouta_indeksoija_service/indexer/indexer.clj
@@ -111,9 +111,9 @@
 
 (defn index-sorakuvaukset
   [ids]
-  (let [entries          (sorakuvaus/do-index ids)
+  (let [entries       (sorakuvaus/do-index ids)
         koulutus-oids (mapcat kouta-backend/list-koulutus-oids-by-sorakuvaus (get-oids :id entries))]
-    (index-koulutukset koulutus-oids)
+    (koulutus/do-index koulutus-oids)
     entries))
 
 (defn index-sorakuvaus

--- a/src/kouta_indeksoija_service/indexer/tools/search.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/search.clj
@@ -261,7 +261,8 @@
        (map-to-konfo-koodit)))
 
 (defn- get-koulutustyypit-without-koodi-uris [koulutus excludedKoulutustyyppiKoodiUri]
-  (concat (filter #(not= % excludedKoulutustyyppiKoodiUri) (koulutustyyppi-koodi-urit koulutus)) (vector (:koulutustyyppi koulutus))))
+  (concat (filter #(not= % excludedKoulutustyyppiKoodiUri) (koulutustyyppi-koodi-urit koulutus))
+          (vector (:koulutustyyppi koulutus))))
 
 (defn deduce-koulutustyypit
   ([koulutus ammatillinen-perustutkinto-erityisopetuksena?]

--- a/test/kouta_indeksoija_service/indexer/kouta_indexer_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_indexer_test.clj
@@ -215,8 +215,8 @@
      (is (nil? (:oid (get-doc hakukohde/index-name hakukohde-oid))))
      (is (nil? (:oid (get-doc toteutus/index-name toteutus-oid))))
      (is (= koulutus-oid (:oid (get-doc koulutus/index-name koulutus-oid))))
-     (is (= koulutus-oid (:oid (get-doc koulutus-search/index-name koulutus-oid))))
-     (is (= mocks/Oppilaitos1 (:oid (get-doc oppilaitos-search/index-name mocks/Oppilaitos1))))
+     (is (nil? (:oid (get-doc koulutus-search/index-name koulutus-oid))))
+     (is (nil? (:oid (get-doc oppilaitos-search/index-name mocks/Oppilaitos1))))
      (is (nil? (:id (get-doc valintaperuste/index-name valintaperuste-id)))))))
 
 (deftest index-all-koulutukset-test

--- a/test/kouta_indeksoija_service/scheduled/scheduled_jobs_test.clj
+++ b/test/kouta_indeksoija_service/scheduled/scheduled_jobs_test.clj
@@ -127,4 +127,5 @@
           (is (= "NORMAL" (job-state jobs/notification-dlq-job-name)))
           (is (= "NORMAL" (job-state jobs/notification-job-name)))
           (is (= "NORMAL" (job-state jobs/queueing-job-name)))
-          (is (= "NORMAL" (job-state jobs/lokalisaatio-indexing-job-name))))))))
+          (is (= "NORMAL" (job-state jobs/lokalisaatio-indexing-job-name)))
+          (jobs/reset-jobs))))))

--- a/test/kouta_indeksoija_service/util/healthcheck_test.clj
+++ b/test/kouta_indeksoija_service/util/healthcheck_test.clj
@@ -70,20 +70,20 @@
                 :elasticsearch-health (expected-queue-health "green" true "red" false)} (body->json response))))))
 
   (testing "deep healthcheck returns 500 queue throws exception"
-    (with-redefs [kouta-indeksoija-service.queue.sqs/get-queue-attributes (fn [p & a] (throw (Exception. "moi")))
-                  kouta-indeksoija-service.elastic.admin/get-elastic-status (partial mock-cluster-health "yellow" "yellow")]
+    (with-redefs [kouta-indeksoija-service.queue.sqs/get-queue-attributes (fn [p & a] (throw (Exception. "Tämä on tarkoituksellinen testin poikkeus")))
+                  kouta-indeksoija-service.elastic.admin/get-elastic-status (partial mock-cluster-health "yellow" "yellow")
+                  clojure.tools.logging/log* (fn [logger level throwable message])]
       (let [response (app (mock/request :get "/kouta-indeksoija/api/healthcheck/deep"))]
         (is (= 500 (:status response)))
-        (is (= {:sqs-health {:error "moi"},
+        (is (= {:sqs-health {:error "Tämä on tarkoituksellinen testin poikkeus"},
                 :elasticsearch-health (expected-queue-health "yellow" true "yellow" true)} (body->json response))))))
 
   (testing "deep healthcheck returns 500 elasticsearch throws exception"
     (with-redefs [kouta-indeksoija-service.queue.sqs/get-queue-attributes (partial mock-queue-attributes 5)
-                  kouta-indeksoija-service.elastic.admin/get-elastic-status (fn [] (throw (Exception. "moi")))]
+                  kouta-indeksoija-service.elastic.admin/get-elastic-status (fn [] (throw (Exception. "Tämän on tarkoituksellinen testin poikkeus")))
+                  clojure.tools.logging/log* (fn [logger level throwable message])]
       (let [response (app (mock/request :get "/kouta-indeksoija/api/healthcheck/deep"))]
         (is (= 500 (:status response)))
         (is (= {:sqs-health (expected-sqs-health 5 true),
-                :elasticsearch-health {:error "moi"}} (body->json response))))))
-
-  )
+                :elasticsearch-health {:error "Tämän on tarkoituksellinen testin poikkeus"}} (body->json response)))))))
 


### PR DESCRIPTION
- Sorakuvauksen indeksoinnissa kutsutaan suoraan koulutuksen indeksointia eikä funktiota joka indeksoi myös koulutukseen liittyviä asioita. Näiden indeksointi ei ole tarpeen
- korjattu testeistä pois virhelogitusta joka häiritsi testien lopputuloksen lukemista