### PR TITLE
Lisää 'sora'-kenttä hakukohteeseen arvolla 'nil', kun sora tietoja ei löydy

### DIFF
--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -23,8 +23,11 @@
 
 (defn- assoc-sora-data
   [hakukohde sora-tiedot]
-  (let [pick-relevant-data #(select-keys % [:tila])]
-    (assoc hakukohde :sora (pick-relevant-data sora-tiedot))))
+    (assoc
+      hakukohde
+      :sora
+      (when sora-tiedot
+        (select-keys sora-tiedot [:tila]))))
 
 (defn- luonnos?
   [haku-tai-hakukohde]


### PR DESCRIPTION
Korjaa semantiikkaa sora-tietoa asetettaessa hakukohteelle
- Jos sora-tietoja ei löydy hakukohteelle, asetetaan siihen `:sora nil`.
- Aiemmin asetettiin `:sora {}`

En lisännyt testiä. Voin testata, jos katselmoijat näkevät tarpeelliseksi. Muutos suht triviaali. 

