### PR TITLE
KTO-1133-korkeakoulumuutos 

### DIFF
--- a/src/kouta_indeksoija_service/indexer/tools/search.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/search.clj
@@ -288,7 +288,7 @@
   (let [tutkintotyyppi-koodi-urit (->> (:koulutuksetKoodiUri koulutus)
                                        (mapcat #(koodisto/tutkintotyypit %))
                                        (map :koodiUri))]
-    (concat (tutkintotyyppi->koulutustyyppi tutkintotyyppi-koodi-urit) ["korkeakoulutus"])))
+    (tutkintotyyppi->koulutustyyppi tutkintotyyppi-koodi-urit)))
 
 ;Konfo-ui:n koulutushaun koulutustyyppi filtteriä varten täytyy tallentaa erinäisiä hakusanoja
 ;koulutus-search indeksin jarjestajan metadatan koulutustyyppi kenttään.
@@ -303,12 +303,11 @@
 ;
 ;3. Korkeakoulutuksille tallennetaan kovakoodattu string, joka päätellään koulutusKoodiUrin avulla
 ;   tutkintotyyppi koodistosta. Esim tutkintotyyppi_13 = kandi tai tutkintotyyppi_12 = amk-ylempi.
-;   Tämän lisäksi tallennetaan string korkeakoulutus
 ;
 ;4. Jos ammatilliselle toteutukselle on valittu amm-perustutkinto-erityisopetuksena kenttä, tallennetaan
 ;   kovakoodattu arvo koulutustyyppi_4 = Ammatillinen perustutkinto erityisopetuksena
 ;
-;Lopputulos on taulukko stringejä, esim. ["amm" "koulutustyyppi_1"] tai ["yo" "maisteri" "korkeakoulutus"]
+;Lopputulos on taulukko stringejä, esim. ["amm" "koulutustyyppi_1"] tai ["yo" "maisteri"]
 (defn- get-koulutustyypit-from-koulutus-koodi
   [koulutus]
   (let [koulutustyyppikoodit (koulutustyyppi-koodi-urit koulutus)

--- a/test/kouta_indeksoija_service/indexer/search_tests/kouta_koulutus_search_integration_test.clj
+++ b/test/kouta_indeksoija_service/indexer/search_tests/kouta_koulutus_search_integration_test.clj
@@ -58,7 +58,7 @@
        (koulutus-search/do-index [koulutus-oid])
        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
              koulutustyypit (get-koulutustyypit koulutus)]
-         (is (= koulutustyypit ["amk" "amk-ylempi" "korkeakoulutus"])))))))
+         (is (= koulutustyypit ["amk" "amk-ylempi"])))))))
 
 (deftest adds-amk-alempi-koulutustyyppi
   (fixture/with-mocked-indexing
@@ -69,7 +69,7 @@
        (koulutus-search/do-index [koulutus-oid])
        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
              koulutustyypit (get-koulutustyypit koulutus)]
-         (is (= koulutustyypit ["amk" "amk-alempi" "korkeakoulutus"])))))))
+         (is (= koulutustyypit ["amk" "amk-alempi"])))))))
 
 (deftest adds-kandi-koulutustyyppi
   (fixture/with-mocked-indexing
@@ -80,7 +80,7 @@
        (koulutus-search/do-index [koulutus-oid])
        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
              koulutustyypit (get-koulutustyypit koulutus)]
-         (is (= koulutustyypit ["yo" "kandi" "korkeakoulutus"])))))))
+         (is (= koulutustyypit ["yo" "kandi"])))))))
 
 (deftest adds-maisteri-koulutustyyppi
   (fixture/with-mocked-indexing
@@ -91,7 +91,7 @@
        (koulutus-search/do-index [koulutus-oid])
        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
              koulutustyypit (get-koulutustyypit koulutus)]
-         (is (= koulutustyypit ["yo" "maisteri" "korkeakoulutus"])))))))
+         (is (= koulutustyypit ["yo" "maisteri"])))))))
 
 (deftest adds-tohtori-koulutustyyppi
   (fixture/with-mocked-indexing
@@ -102,7 +102,7 @@
        (koulutus-search/do-index [koulutus-oid])
        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
              koulutustyypit (get-koulutustyypit koulutus)]
-         (is (= koulutustyypit ["yo" "tohtori" "korkeakoulutus"])))))))
+         (is (= koulutustyypit ["yo" "tohtori"])))))))
 
 (deftest adds-kandi-ja-maisteri-koulutustyyppi
   (fixture/with-mocked-indexing
@@ -113,7 +113,7 @@
        (koulutus-search/do-index [koulutus-oid])
        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
              koulutustyypit (get-koulutustyypit koulutus)]
-         (is (= koulutustyypit ["yo" "kandi-ja-maisteri" "korkeakoulutus"])))))))
+         (is (= koulutustyypit ["yo" "kandi-ja-maisteri"])))))))
 
 (deftest adds-kandi-ja-maisteri-if-tukintotyypit-contains-those
   (fixture/with-mocked-indexing
@@ -124,7 +124,7 @@
        (koulutus-search/do-index [koulutus-oid])
        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
              koulutustyypit (get-koulutustyypit koulutus)]
-         (is (= koulutustyypit ["yo" "kandi-ja-maisteri" "korkeakoulutus"])))))))
+         (is (= koulutustyypit ["yo" "kandi-ja-maisteri"])))))))
 
 (deftest adds-kandi-if-multiple-kandi-koulutuskoodi
   (fixture/with-mocked-indexing
@@ -135,7 +135,7 @@
        (koulutus-search/do-index [koulutus-oid])
        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
              koulutustyypit (get-koulutustyypit koulutus)]
-         (is (= koulutustyypit ["yo" "kandi" "korkeakoulutus"])))))))
+         (is (= koulutustyypit ["yo" "kandi"])))))))
 
 (deftest adds-maisteri-if-multiple-maisteri-koulutuskoodi
   (fixture/with-mocked-indexing
@@ -146,7 +146,7 @@
        (koulutus-search/do-index [koulutus-oid])
        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
              koulutustyypit (get-koulutustyypit koulutus)]
-         (is (= koulutustyypit ["yo" "maisteri" "korkeakoulutus"])))))))
+         (is (= koulutustyypit ["yo" "maisteri"])))))))
 
 (deftest adds-tohtori-if-multiple-tohtori-koulutuskoodi
   (fixture/with-mocked-indexing
@@ -157,4 +157,4 @@
        (koulutus-search/do-index [koulutus-oid])
        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
              koulutustyypit (get-koulutustyypit koulutus)]
-         (is (= koulutustyypit ["yo" "tohtori" "korkeakoulutus"])))))))
+         (is (= koulutustyypit ["yo" "tohtori"])))))))


### PR DESCRIPTION
Poistettu mahdollisuus filtteröidä korkeakoulutuksia, jatkossa filtteröidään amk tai yo filttereillä ja jos haluaa kaikki korkeakoulut, täytyy valita nuo molemmat filtterit.