### PR TITLE
KTO-1149: Palautetaan lukiokoulutuksen tutkintonimike vectorina

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
   "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject kouta-indeksoija-service "7.4.0-SNAPSHOT"
+(defproject kouta-indeksoija-service "7.5.0-SNAPSHOT"
   :description "Kouta-indeksoija"
   :repositories [["releases" {:url "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"
                               :username :env/artifactory_username

--- a/src/kouta_indeksoija_service/indexer/kouta/koulutus.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/koulutus.clj
@@ -88,7 +88,7 @@
   [koulutus]
   (-> koulutus
       (assoc-in [:metadata :opintojenLaajuusyksikko] (get-opintopiste-laajuusyksikko))
-      (assoc-in [:metadata :tutkintonimike] (get-koodi-nimi-with-cache ylioppilas-tutkintonimikekoodi))))
+      (assoc-in [:metadata :tutkintonimike] (vector (get-koodi-nimi-with-cache ylioppilas-tutkintonimikekoodi)))))
 
 (defn- does-not-have-tutkintonimike?
   [koulutus]

--- a/test/kouta_indeksoija_service/indexer/kouta_koulutus_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_koulutus_test.clj
@@ -156,7 +156,10 @@
        (check-all-nil)
        (i/index-koulutukset [koulutus-oid])
        (let [koulutus (get-doc koulutus/index-name koulutus-oid)
-             tutkintonimike (get-in koulutus [:metadata :tutkintonimike :nimi :fi])
+             tutkintonimike (-> koulutus
+                                (get-in [:metadata :tutkintonimike])
+                                (first)
+                                (get-in [:nimi :fi]))
              opintojen-laajuus (get-in koulutus [:metadata :opintojenLaajuus :nimi :fi])
              opintojen-laajuusyksikko (get-in koulutus [:metadata :opintojenLaajuusyksikko :nimi :fi])
              koulutusala (-> koulutus


### PR DESCRIPTION
- Palautetaan lukiokoulutuksen tutkintonimike vectorina
- Nostettu indeksoijan minor versiota