### PR TITLE
Add 'onkoHarkinnanvarainenKoulutus' field to hakukohde model

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
   "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject kouta-indeksoija-service "7.7.0-SNAPSHOT"
+(defproject kouta-indeksoija-service "7.8.0-SNAPSHOT"
   :description "Kouta-indeksoija"
   :repositories [["releases" {:url "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"
                               :username :env/artifactory_username

--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -1,7 +1,7 @@
 (ns kouta-indeksoija-service.indexer.kouta.hakukohde
   (:require [kouta-indeksoija-service.rest.kouta :as kouta-backend]
             [kouta-indeksoija-service.indexer.kouta.common :as common]
-            [kouta-indeksoija-service.indexer.tools.general :as general]
+            [kouta-indeksoija-service.indexer.tools.general :refer [Tallennettu korkeakoulutus?]]
             [kouta-indeksoija-service.indexer.indexable :as indexable]
             [kouta-indeksoija-service.indexer.tools.koodisto :as koodisto]))
 
@@ -31,7 +31,7 @@
 
 (defn- luonnos?
   [haku-tai-hakukohde]
-  (= "tallennettu" (:tila haku-tai-hakukohde)))
+  (= Tallennettu (:tila haku-tai-hakukohde)))
 
 (defn- johtaa-tutkintoon?
   [koulutus]
@@ -89,7 +89,7 @@
          (luonnos? hakukohde)
          (->ei-yps "Hakukohde on luonnos tilassa")
 
-         (not (general/korkeakoulutus? koulutus))
+         (not (korkeakoulutus? koulutus))
          (->ei-yps "Ei korkeakoulutus koulutusta")
 
          (not (johtaa-tutkintoon? koulutus))

--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -127,6 +127,11 @@
        (conj-er-koulutus toteutus)
        (assoc hakukohde :koulutustyypit)))
 
+(defn- assoc-onko-harkinnanvarainen-koulutus
+       [hakukohde {:keys [koulutuksetKoodiUri] :as koulutus}]
+       (let [ei-harkinnanvaraisuutta-alakoodi (koodisto/ei-harkinnanvaraisuutta (first koulutuksetKoodiUri))]
+            (assoc hakukohde :onkoHarkinnanvarainenKoulutus (nil? ei-harkinnanvaraisuutta-alakoodi))))
+
 (defn create-index-entry
   [oid]
   (let [hakukohde      (kouta-backend/get-hakukohde oid)
@@ -143,6 +148,7 @@
                                  (assoc-yps haku koulutus)
                                  (common/complete-entry)
                                  (assoc-sora-data sora-kuvaus)
+                                 (assoc-onko-harkinnanvarainen-koulutus koulutus)
                                  (assoc-koulutustyypit toteutus koulutus)
                                  (assoc-toteutus toteutus)
                                  (assoc-valintaperuste valintaperuste)

--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -1,7 +1,7 @@
 (ns kouta-indeksoija-service.indexer.kouta.hakukohde
   (:require [kouta-indeksoija-service.rest.kouta :as kouta-backend]
             [kouta-indeksoija-service.indexer.kouta.common :as common]
-            [kouta-indeksoija-service.indexer.tools.general :refer [Tallennettu korkeakoulutus?]]
+            [kouta-indeksoija-service.indexer.tools.general :refer [Tallennettu korkeakoulutus? get-non-korkeakoulu-koodi-uri]]
             [kouta-indeksoija-service.indexer.indexable :as indexable]
             [kouta-indeksoija-service.indexer.tools.koodisto :as koodisto]))
 
@@ -128,8 +128,8 @@
        (assoc hakukohde :koulutustyypit)))
 
 (defn- assoc-onko-harkinnanvarainen-koulutus
-       [hakukohde {:keys [koulutuksetKoodiUri] :as koulutus}]
-       (let [ei-harkinnanvaraisuutta-alakoodi (koodisto/ei-harkinnanvaraisuutta (first koulutuksetKoodiUri))]
+       [hakukohde koulutus]
+       (let [ei-harkinnanvaraisuutta-alakoodi (koodisto/ei-harkinnanvaraisuutta (get-non-korkeakoulu-koodi-uri koulutus))]
             (assoc hakukohde :onkoHarkinnanvarainenKoulutus (nil? ei-harkinnanvaraisuutta-alakoodi))))
 
 (defn create-index-entry

--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -128,9 +128,11 @@
        (assoc hakukohde :koulutustyypit)))
 
 (defn- assoc-onko-harkinnanvarainen-koulutus
-       [hakukohde koulutus]
-       (let [ei-harkinnanvaraisuutta-alakoodi (koodisto/ei-harkinnanvaraisuutta (get-non-korkeakoulu-koodi-uri koulutus))]
-            (assoc hakukohde :onkoHarkinnanvarainenKoulutus (nil? ei-harkinnanvaraisuutta-alakoodi))))
+  [hakukohde koulutus]
+  (let [non-korkeakoulu-koodi-uri (get-non-korkeakoulu-koodi-uri koulutus)]
+    (assoc hakukohde :onkoHarkinnanvarainenKoulutus (and
+                                                      (some? non-korkeakoulu-koodi-uri)
+                                                      (nil? (koodisto/ei-harkinnanvaraisuutta non-korkeakoulu-koodi-uri))))))
 
 (defn create-index-entry
   [oid]

--- a/src/kouta_indeksoija_service/indexer/tools/general.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/general.clj
@@ -34,7 +34,7 @@
 
 (defn get-non-korkeakoulu-koodi-uri
   [koulutus]
-  (when (any-ammatillinen? koulutus)
+  (when (not (korkeakoulutus? koulutus))
     (-> koulutus
         (:koulutuksetKoodiUri)
         (first)))) ;Ainoastaan korkeakoulutuksilla voi olla useampi kuin yksi koulutusKoodi

--- a/src/kouta_indeksoija_service/indexer/tools/general.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/general.clj
@@ -34,9 +34,10 @@
 
 (defn get-non-korkeakoulu-koodi-uri
   [koulutus]
-  (-> koulutus
-      (:koulutuksetKoodiUri)
-      (first))) ;Ainoastaan korkeakoulutuksilla voi olla useampi kuin yksi koulutusKoodi
+  (when (any-ammatillinen? koulutus)
+    (-> koulutus
+        (:koulutuksetKoodiUri)
+        (first)))) ;Ainoastaan korkeakoulutuksilla voi olla useampi kuin yksi koulutusKoodi
 
 (defn asiasana->lng-value-map
   [asiasanat]

--- a/src/kouta_indeksoija_service/indexer/tools/general.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/general.clj
@@ -32,6 +32,12 @@
   [koulutus]
   (or (ammatillinen? koulutus) (amm-osaamisala? koulutus) (amm-tutkinnon-osa? koulutus)))
 
+(defn get-non-korkeakoulu-koodi-uri
+  [koulutus]
+  (-> koulutus
+      (:koulutuksetKoodiUri)
+      (first))) ;Ainoastaan korkeakoulutuksilla voi olla useampi kuin yksi koulutusKoodi
+
 (defn asiasana->lng-value-map
   [asiasanat]
   (map (fn [a] {(keyword (:kieli a)) (:arvo a)}) asiasanat))

--- a/src/kouta_indeksoija_service/indexer/tools/koodisto.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/koodisto.clj
@@ -47,6 +47,10 @@
   [koulutusKoodiUri]
   (list-alakoodi-nimet-with-cache koulutusKoodiUri "tutkintotyyppi"))
 
+(defn ei-harkinnanvaraisuutta
+  [koulutusKoodiUri]
+  (get-alakoodi-nimi-with-cache koulutusKoodiUri "hakulomakkeenasetukset_eiharkinnanvaraisuutta"))
+
 (defn pohjakoulutusvaatimuskonfo
   []
   (map #(assoc % :alakoodit (list-alakoodit-with-cache (:koodiUri %) "pohjakoulutusvaatimuskouta"))

--- a/src/kouta_indeksoija_service/indexer/tools/search.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/search.clj
@@ -1,5 +1,5 @@
 (ns kouta-indeksoija-service.indexer.tools.search
-  (:require [kouta-indeksoija-service.indexer.tools.general :refer [amm-osaamisala? amm-tutkinnon-osa? any-ammatillinen? ammatillinen? korkeakoulutus? lukio? julkaistu?]]
+  (:require [kouta-indeksoija-service.indexer.tools.general :refer [amm-osaamisala? amm-tutkinnon-osa? any-ammatillinen? ammatillinen? korkeakoulutus? lukio? julkaistu? get-non-korkeakoulu-koodi-uri]]
             [kouta-indeksoija-service.indexer.tools.koodisto :as koodisto]
             [kouta-indeksoija-service.rest.koodisto :refer [extract-versio get-koodi-nimi-with-cache]]
             [kouta-indeksoija-service.indexer.tools.tyyppi :refer [remove-uri-version koodi-arvo oppilaitostyyppi-uri-to-tyyppi]]
@@ -110,12 +110,6 @@
                                     (map #(some-> % :koulutusKoodiUri remove-uri-version))
                                     (->distinct-vec))]
     (->distinct-vec (mapcat get-koulutusalatasot-by-koulutus-koodi-uri koulutusKoodiUrit))))
-
-(defn- get-non-korkeakoulu-koodi-uri
-  [koulutus]
-  (-> koulutus
-      (:koulutuksetKoodiUri)
-      (first))) ;Ainoastaan korkeakoulutuksilla voi olla useampi kuin yksi koulutusKoodi
 
 (defn koulutusala-koodi-urit
   [koulutus]

--- a/src/kouta_indeksoija_service/indexer/tools/search.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/search.clj
@@ -131,7 +131,7 @@
     (get-in koulutus [:metadata :koulutusalaKoodiUrit])))
 
 ;TODO korvaa pelkällä get-eperuste-by-id, kun kaikki tuotantodata käyttää ePeruste id:tä
-(defn- get-eperuste
+(defn- get-ammatillinen-eperuste
   [koulutus]
   (let [eperuste-id (:ePerusteId koulutus)]
     (if eperuste-id
@@ -140,7 +140,7 @@
 
 (defn tutkintonimike-koodi-urit
   [koulutus]
-  (cond (ammatillinen? koulutus) (when-let [eperuste (get-eperuste koulutus)]
+  (cond (ammatillinen? koulutus) (when-let [eperuste (get-ammatillinen-eperuste koulutus)]
                                    (->distinct-vec (map :tutkintonimikeUri (:tutkintonimikkeet eperuste))))
         (lukio? koulutus) (vector koodisto/koodiuri-ylioppilas-tutkintonimike)
         :else (get-in koulutus [:metadata :tutkintonimikeKoodiUrit] [])))
@@ -169,22 +169,22 @@
 (defn opintojen-laajuus-koodi-uri
   [koulutus]
   (cond
-    (ammatillinen? koulutus)   (-> koulutus (get-eperuste) (get-in [:opintojenLaajuus :koodiUri]))
-    (amm-osaamisala? koulutus) (-> koulutus (get-eperuste) (get-osaamisala koulutus) (get-in [:opintojenLaajuus :koodiUri]))
+    (ammatillinen? koulutus)   (-> koulutus (get-ammatillinen-eperuste) (get-in [:opintojenLaajuus :koodiUri]))
+    (amm-osaamisala? koulutus) (-> koulutus (get-ammatillinen-eperuste) (get-osaamisala koulutus) (get-in [:opintojenLaajuus :koodiUri]))
     :default                   (get-in koulutus [:metadata :opintojenLaajuusKoodiUri])))
 
 (defn opintojen-laajuus-numero
   [koulutus]
   (cond
-    (ammatillinen? koulutus)   (-> koulutus (get-eperuste) :opintojenLaajuusNumero)
-    (amm-osaamisala? koulutus) (-> koulutus (get-eperuste) (get-osaamisala koulutus) :opintojenLaajuusNumero)
+    (ammatillinen? koulutus)   (-> koulutus (get-ammatillinen-eperuste) :opintojenLaajuusNumero)
+    (amm-osaamisala? koulutus) (-> koulutus (get-ammatillinen-eperuste) (get-osaamisala koulutus) :opintojenLaajuusNumero)
     :default                   (-> (get-in koulutus [:metadata :opintojenLaajuusKoodiUri]) koodi-arvo)))
 
 (defn opintojen-laajuusyksikko-koodi-uri
   [koulutus]
   (cond
-    (ammatillinen? koulutus)   (-> koulutus (get-eperuste) (get-in [:opintojenLaajuusyksikko :koodiUri]))
-    (amm-osaamisala? koulutus) (-> koulutus (get-eperuste) (get-in [:opintojenLaajuusyksikko :koodiUri]))
+    (ammatillinen? koulutus)   (-> koulutus (get-ammatillinen-eperuste) (get-in [:opintojenLaajuusyksikko :koodiUri]))
+    (amm-osaamisala? koulutus) (-> koulutus (get-ammatillinen-eperuste) (get-in [:opintojenLaajuusyksikko :koodiUri]))
     (korkeakoulutus? koulutus) koodisto/koodiuri-opintopiste-laajuusyksikko
     (lukio? koulutus) koodisto/koodiuri-opintopiste-laajuusyksikko
     :else nil))
@@ -205,7 +205,7 @@
 
 (defn osaamisala-koodi-uri
   [koulutus]
-  (some-> (get-eperuste koulutus)
+  (some-> (get-ammatillinen-eperuste koulutus)
           (get-osaamisala koulutus)
           (:koodiUri)))
 

--- a/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
@@ -64,6 +64,15 @@
        (is (true? (:voimassa yhden-paikan-saanto)))
        (is (= "Hakukohde on yhden paikan säännön piirissä" (:syy yhden-paikan-saanto)))))))
 
+(deftest harkinnanvaraisuus-for-korkeakoulu
+  (fixture/with-mocked-indexing
+   (testing "Korkeakoulutus should never be harkinnanvarainen"
+     (check-all-nil)
+     (fixture/update-koulutus-mock koulutus-oid :koulutustyyppi "yo" :metadata fixture/yo-koulutus-metadata)
+     (i/index-hakukohteet [hakukohde-oid])
+     (let [hakukohde (get-doc hakukohde/index-name hakukohde-oid)]
+       (is (nil? (:onkoHarkinnanvarainenKoulutus hakukohde)))))))
+
 (deftest index-hakukohde-hakulomakelinkki-test
   (fixture/with-mocked-indexing
    (testing "Indexer should create hakulomakeLinkki from haku oid"

--- a/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
@@ -71,7 +71,7 @@
      (fixture/update-koulutus-mock koulutus-oid :koulutustyyppi "yo" :metadata fixture/yo-koulutus-metadata)
      (i/index-hakukohteet [hakukohde-oid])
      (let [hakukohde (get-doc hakukohde/index-name hakukohde-oid)]
-       (is (nil? (:onkoHarkinnanvarainenKoulutus hakukohde)))))))
+       (is (false? (:onkoHarkinnanvarainenKoulutus hakukohde)))))))
 
 (deftest index-hakukohde-hakulomakelinkki-test
   (fixture/with-mocked-indexing

--- a/test/resources/kouta/kouta-hakukohde-result.json
+++ b/test/resources/kouta/kouta-hakukohde-result.json
@@ -452,5 +452,6 @@
   "sora": {
     "tila": "arkistoitu"
   },
+  "onkoHarkinnanvarainenKoulutus": false,
   "koulutustyypit": ["koulutustyyppi_01", "koulutustyyppi_02"]
 }


### PR DESCRIPTION
Liittyy tiketin B-kohtaan:
https://jira.eduuni.fi/browse/HLE-1334

Hakukohderyhmäpalvelussa tarve selvittää, kuuluuko hakukohteen toteutuksen koulutuksen koulutuskoodiin seuraava alakoodi https://virkailija.testiopintopolku.fi/koodisto-ui/html/koodi/hakulomakkeenasetukset_eiharkinnanvaraisuutta/1.

Tieto on suht. hankalasti saatavilla, tämä vaikutti parhaalta tavalta päästä siihen käsiksi.