### PR TITLE
KTO-1228: Urheiluoppilaitoksen lisävalinta + pari pientä parannusta

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ sellainen tarve tulee.
 
 Kun Elasticsearch ja sqs-jonot ovat pyörimässä indeksoijan saa käyntiin komennolla `lein run`
 
-Tämä avaa swaggerin selaimeen osoitteeseen `http://localhost:3000/kouta-indeksoija/swagger/index.html`
+Tämä avaa swaggerin selaimeen osoitteeseen `http://localhost:8100/kouta-indeksoija/swagger/index.html`
 
 ### 3.4. Kehitystyökalut
 

--- a/README_INDEKSOINTI.md
+++ b/README_INDEKSOINTI.md
@@ -10,49 +10,49 @@ Huom! Konfo-backendiä ei saa asentaa uudelleen, kun katkoton indeksointi on kes
 
 1. Luo kouta-indeksit uudelleen kutsumalla
    
-   * [POST /kouta-indeksoija/api/rebuild/indices/kouta](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/post_kouta_indeksoija_api_rebuild_indices_kouta)
+   * [POST /kouta-indeksoija/api/rebuild/indices/kouta](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/post_kouta_indeksoija_api_rebuild_indices_kouta)
 
    Voit myös luoda uudelleen ihan kaikki indeksit tai vain koodisto- tai eperuste-indeksit
 
-   * [POST /kouta-indeksoija/api/rebuild/indices/koodisto](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/post_kouta_indeksoija_api_rebuild_indices_koodisto)
-   * [POST /kouta-indeksoija/api/rebuild/indices/eperuste](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/post_kouta_indeksoija_api_rebuild_indices_eperuste)
-   * [POST /kouta-indeksoija/api/rebuild/indices/all](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/post_kouta_indeksoija_api_rebuild_indices_all)
+   * [POST /kouta-indeksoija/api/rebuild/indices/koodisto](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/post_kouta_indeksoija_api_rebuild_indices_koodisto)
+   * [POST /kouta-indeksoija/api/rebuild/indices/eperuste](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/post_kouta_indeksoija_api_rebuild_indices_eperuste)
+   * [POST /kouta-indeksoija/api/rebuild/indices/all](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/post_kouta_indeksoija_api_rebuild_indices_all)
 
 2. Nyt virkailijan etusivulla ei enää näy mitään muuta kuin indeksien luonnin jälkeen tehdyt muutokset. 
 Oppijan puolella taas näkyy kaikki kuten ennenkin, mutta uudet muutokset eivät välity sinne.
 
 3. Voit nyt nähdä listauksesta, että oppijan ja virkailijan puoli käyttävät eri indeksejä:
 
-   * [GET /kouta-indeksoija/api/rebuild/indices/list/virkailija](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/get_kouta_indeksoija_api_rebuild_indices_list_virkailija)
-   * [GET /kouta-indeksoija/api/rebuild/indices/list/oppija](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/get_kouta_indeksoija_api_rebuild_indices_list_oppija)
+   * [GET /kouta-indeksoija/api/rebuild/indices/list/virkailija](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/get_kouta_indeksoija_api_rebuild_indices_list_virkailija)
+   * [GET /kouta-indeksoija/api/rebuild/indices/list/oppija](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/get_kouta_indeksoija_api_rebuild_indices_list_oppija)
 
-   Kaikki indeksit ja aliakset näkyvät listauksessa: [GET /kouta-indeksoija/api/rebuild/indices/list](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/get_kouta_indeksoija_api_rebuild_indices_list)
+   Kaikki indeksit ja aliakset näkyvät listauksessa: [GET /kouta-indeksoija/api/rebuild/indices/list](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/get_kouta_indeksoija_api_rebuild_indices_list)
    
 4. Indeksoi kouta-data (ja oppilaitokset) uusiin indekseihin:
 
-   * [POST /kouta-indeksoija/api/kouta/all](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/kouta/post_kouta_indeksoija_api_kouta_all)
-   * [POST /kouta-indeksoija/api/queuer/oppilaitokset](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/queuer/post_kouta_indeksoija_api_queuer_oppilaitokset)
+   * [POST /kouta-indeksoija/api/kouta/all](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/kouta/post_kouta_indeksoija_api_kouta_all)
+   * [POST /kouta-indeksoija/api/queuer/oppilaitokset](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/queuer/post_kouta_indeksoija_api_queuer_oppilaitokset)
 
    Jos olet luonut uudelleen koodisto- tai eperuste-indeksit, indeksoi myös ne: 
 
-   * [POST /kouta-indeksoija/api/indexer/koodistot](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/indexer/post_kouta_indeksoija_api_indexer_koodistot)
-   * [POST /kouta-indeksoija/api/queuer/eperusteet](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/queuer/post_kouta_indeksoija_api_queuer_eperusteet)
+   * [POST /kouta-indeksoija/api/indexer/koodistot](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/indexer/post_kouta_indeksoija_api_indexer_koodistot)
+   * [POST /kouta-indeksoija/api/queuer/eperusteet](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/queuer/post_kouta_indeksoija_api_queuer_eperusteet)
 
    Eperusteiden ja oppilaitosten indeksointi menee sqs-jonojen kautta. Voit tarkastalle viestien määrää "fast"-jonosta kentästä ApproximateNumberOfMessages 
    
-   * [GET /kouta-indeksoija/api/admin/queue/status](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/admin/get_kouta_indeksoija_api_admin_queue_status)
+   * [GET /kouta-indeksoija/api/admin/queue/status](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/admin/get_kouta_indeksoija_api_admin_queue_status)
 
 5. Kun indeksointi on valmis, sykronoi oppijan ja virkailijan puolen aliakset
 
-   Voit tehdä tämän joko kutsumalla rajapintaa [POST /kouta-indeksoija/api/rebuild/indices/aliases/sync](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/post_kouta_indeksoija_api_rebuild_indices_aliases_sync) 
+   Voit tehdä tämän joko kutsumalla rajapintaa [POST /kouta-indeksoija/api/rebuild/indices/aliases/sync](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/post_kouta_indeksoija_api_rebuild_indices_aliases_sync) 
    tai *asentamalla konfo-backendin uudelleen*! Konfo-backend sykronoi aliakset automaattisesti deployn yhteydessä, jos ne eivät ole synkassa.
 
 6. Voit nyt nähdä listauksista, että oppijan ja virkailijan puoli käyttävät samoja indeksejä.
 
 7. Tämän jälkeen deletoi vanhat indeksit. 
 
-   1. Varmista ensin listasta, että olet poistamassa oikeita indeksejä: [GET /kouta-indeksoija/api/rebuild/indices/list/unused](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/get_kouta_indeksoija_api_rebuild_indices_list_unused)
+   1. Varmista ensin listasta, että olet poistamassa oikeita indeksejä: [GET /kouta-indeksoija/api/rebuild/indices/list/unused](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/get_kouta_indeksoija_api_rebuild_indices_list_unused)
  
-   2. Sen jälkeen voit ajaa deleten: [DELETE /kouta-indeksoija/api/rebuild/indices/unused](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/delete_kouta_indeksoija_api_rebuild_indices_unused)
+   2. Sen jälkeen voit ajaa deleten: [DELETE /kouta-indeksoija/api/rebuild/indices/unused](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/delete_kouta_indeksoija_api_rebuild_indices_unused)
   
-   3. Voit myös poistaa vain haluamasi setin indeksejä: [DELETE /kouta-indeksoija/api/rebuild/indices](http://localhost:3000/kouta-indeksoija/swagger/index.html#!/rebuild/delete_kouta_indeksoija_api_rebuild_indices)
+   3. Voit myös poistaa vain haluamasi setin indeksejä: [DELETE /kouta-indeksoija/api/rebuild/indices](http://localhost:8100/kouta-indeksoija/swagger/index.html#!/rebuild/delete_kouta_indeksoija_api_rebuild_indices)

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (require 'cemerick.pomegranate.aether)
 (cemerick.pomegranate.aether/register-wagon-factory!
-  "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
+ "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
 (defproject kouta-indeksoija-service "8.2.0-SNAPSHOT"
   :description "Kouta-indeksoija"
@@ -64,8 +64,7 @@
                                   [ring/ring-mock "0.3.0"]
                                   [org.clojure/tools.namespace "0.2.11"]
                                   [criterium "0.4.4"]
-                                  [pjstadig/humane-test-output "0.11.0"]
-                                  ]
+                                  [pjstadig/humane-test-output "0.11.0"]]
                    :plugins [[lein-ring "0.12.5"]
                              [jonase/eastwood "0.3.5"]
                              [lein-kibit "0.1.3" :exclusions [org.clojure/clojure]]
@@ -73,12 +72,12 @@
                              [lein-cloverage "1.1.1" :exclusions [org.clojure/clojure]]]
                    :resource-paths ["dev_resources"]
                    :env {:dev "true"}
-                   :ring {:reload-paths ["src"]}
+                   :ring {:reload-paths ["src"]
+                          :port 8100}
                    :jvm-opts ["-Daws.accessKeyId=randomKeyIdForLocalstack"
                               "-Daws.secretKey=randomKeyForLocalstack"]
                    :injections [(require 'pjstadig.humane-test-output)
-                                (pjstadig.humane-test-output/activate!)]
-                   }
+                                (pjstadig.humane-test-output/activate!)]}
              :test {:env {:test "true"} :dependencies [[cloud.localstack/localstack-utils "0.1.22"]
                                                        [fi.oph.kouta/kouta-backend "6.12.0-SNAPSHOT"]
                                                        [fi.oph.kouta/kouta-backend "6.12.0-SNAPSHOT" :classifier "tests"]

--- a/project.clj
+++ b/project.clj
@@ -79,8 +79,8 @@
                    :injections [(require 'pjstadig.humane-test-output)
                                 (pjstadig.humane-test-output/activate!)]}
              :test {:env {:test "true"} :dependencies [[cloud.localstack/localstack-utils "0.1.22"]
-                                                       [fi.oph.kouta/kouta-backend "6.14.0-SNAPSHOT"]
-                                                       [fi.oph.kouta/kouta-backend "6.14.0-SNAPSHOT" :classifier "tests"]
+                                                       [fi.oph.kouta/kouta-backend "6.14.1-SNAPSHOT"]
+                                                       [fi.oph.kouta/kouta-backend "6.14.1-SNAPSHOT" :classifier "tests"]
                                                        [fi.oph.kouta/kouta-common "2.3.0-SNAPSHOT" :classifier "tests"]
                                                        [oph/clj-test-utils "0.2.8-SNAPSHOT"]]
                     :resource-paths ["test_resources"]
@@ -92,8 +92,8 @@
              :ci-test {:env {:test "true"}
                        :dependencies [[ring/ring-mock "0.3.2"]
                                       [cloud.localstack/localstack-utils "0.1.22"]
-                                      [fi.oph.kouta/kouta-backend "6.14.0-SNAPSHOT"]
-                                      [fi.oph.kouta/kouta-backend "6.14.0-SNAPSHOT" :classifier "tests"]
+                                      [fi.oph.kouta/kouta-backend "6.14.1-SNAPSHOT"]
+                                      [fi.oph.kouta/kouta-backend "6.14.1-SNAPSHOT" :classifier "tests"]
                                       [fi.oph.kouta/kouta-common "2.3.0-SNAPSHOT" :classifier "tests"]
                                       [oph/clj-test-utils "0.2.8-SNAPSHOT"]]
                        :jvm-opts ["-Dlog4j.configurationFile=dev_resources/log4j2.properties"

--- a/project.clj
+++ b/project.clj
@@ -79,8 +79,8 @@
                    :injections [(require 'pjstadig.humane-test-output)
                                 (pjstadig.humane-test-output/activate!)]}
              :test {:env {:test "true"} :dependencies [[cloud.localstack/localstack-utils "0.1.22"]
-                                                       [fi.oph.kouta/kouta-backend "6.12.0-SNAPSHOT"]
-                                                       [fi.oph.kouta/kouta-backend "6.12.0-SNAPSHOT" :classifier "tests"]
+                                                       [fi.oph.kouta/kouta-backend "6.14.0-SNAPSHOT"]
+                                                       [fi.oph.kouta/kouta-backend "6.14.0-SNAPSHOT" :classifier "tests"]
                                                        [fi.oph.kouta/kouta-common "2.3.0-SNAPSHOT" :classifier "tests"]
                                                        [oph/clj-test-utils "0.2.8-SNAPSHOT"]]
                     :resource-paths ["test_resources"]
@@ -92,8 +92,8 @@
              :ci-test {:env {:test "true"}
                        :dependencies [[ring/ring-mock "0.3.2"]
                                       [cloud.localstack/localstack-utils "0.1.22"]
-                                      [fi.oph.kouta/kouta-backend "6.12.0-SNAPSHOT"]
-                                      [fi.oph.kouta/kouta-backend "6.12.0-SNAPSHOT" :classifier "tests"]
+                                      [fi.oph.kouta/kouta-backend "6.14.0-SNAPSHOT"]
+                                      [fi.oph.kouta/kouta-backend "6.14.0-SNAPSHOT" :classifier "tests"]
                                       [fi.oph.kouta/kouta-common "2.3.0-SNAPSHOT" :classifier "tests"]
                                       [oph/clj-test-utils "0.2.8-SNAPSHOT"]]
                        :jvm-opts ["-Dlog4j.configurationFile=dev_resources/log4j2.properties"

--- a/resources/kouta-indeksoija-oph.properties
+++ b/resources/kouta-indeksoija-oph.properties
@@ -45,6 +45,7 @@ kouta-backend.hakukohde.oid =                    ${kouta-backend.internal.base}/
 kouta-backend.valintaperuste.id =                ${kouta-backend.internal.base}/valintaperuste/$1
 kouta-backend.sorakuvaus.id =                    ${kouta-backend.internal.base}/sorakuvaus/$1
 kouta-backend.oppilaitos.oid =                   ${kouta-backend.internal.base}/oppilaitos/$1
+kouta-backend.oppilaitoksen-osa.oid =            ${kouta-backend.internal.base}/oppilaitoksen-osa/$1
 kouta-backend.indexer =                          ${kouta-backend.internal.base}/indexer
 kouta-backend.modified-since =                   ${kouta-backend.indexer}/modifiedSince/$1
 kouta-backend.tarjoaja.koulutukset =             ${kouta-backend.indexer}/tarjoaja/$1/koulutukset

--- a/resources/kouta-indeksoija-oph.properties
+++ b/resources/kouta-indeksoija-oph.properties
@@ -59,6 +59,7 @@ kouta-backend.haku.toteutukset-list =            ${kouta-backend.indexer}/haku/$
 kouta-backend.valintaperuste.hakukohteet-list =  ${kouta-backend.indexer}/valintaperuste/$1/hakukohteet/list
 kouta-backend.sorakuvaus.koulutukset-list =      ${kouta-backend.indexer}/sorakuvaus/$1/koulutukset/list
 kouta-backend.oppilaitos.osat =                  ${kouta-backend.indexer}/oppilaitos/$1/osat
+kouta-backend.jarjestyspaikka.hakukohde-oids =   ${kouta-backend.indexer}/jarjestyspaikka/$1/hakukohde-oids
 
 kouta-external.internal.base =                   ${host-kouta-external}/kouta-external
 kouta-external.koulutus =                        ${kouta-external.internal.base}/koulutus

--- a/src/kouta_indeksoija_service/api.clj
+++ b/src/kouta_indeksoija_service/api.clj
@@ -60,7 +60,7 @@
   (if notify (notifier/notify {keyword result}))
   (ok {:result result}))
 
-(def service-api
+(def app
   (api
    {:swagger {:ui "/kouta-indeksoija/swagger"
               :spec "/kouta-indeksoija/swagger.json"
@@ -437,8 +437,3 @@
    (undocumented
     ;; Static resources path. (resources/public, /public path is implicit for route/resources.)
     (route/resources "/kouta-indeksoija/"))))
-
-(def app
-  (-> service-api
-      ;TODO REMOVE CORS SUPPORT WHEN ui APIs are moved to another project
-      (wrap-cors :access-control-allow-origin [#"http://localhost:3005"] :access-control-allow-methods [:get])))

--- a/src/kouta_indeksoija_service/indexer/indexer.clj
+++ b/src/kouta_indeksoija_service/indexer/indexer.clj
@@ -137,15 +137,15 @@
 (defn index-oppilaitokset
   [oids]
   (let [get-organisaation-koulutukset (fn [oid] (let [result (map :oid (some-> oid
-                                                                  (hierarkia/get-hierarkia)
-                                                                  (organisaatio-tool/find-oppilaitos-from-hierarkia)
-                                                                  (:oid)
-                                                                  (kouta-backend/get-koulutukset-by-tarjoaja)))]
-                                                  result))]
-    (let [entries (oppilaitos/do-index oids)]
-      (oppilaitos-search/do-index oids)
-      (koulutus-search/do-index (mapcat get-organisaation-koulutukset oids))
-      entries)))
+                                                                               (hierarkia/get-hierarkia)
+                                                                               (organisaatio-tool/find-oppilaitos-from-hierarkia)
+                                                                               (:oid)
+                                                                               (kouta-backend/get-koulutukset-by-tarjoaja)))] result))
+        entries (oppilaitos/do-index oids)]
+    (oppilaitos-search/do-index oids)
+    (koulutus-search/do-index (mapcat get-organisaation-koulutukset oids))
+    (hakukohde/do-index (mapcat kouta-backend/get-hakukohde-oids-by-jarjestyspaikka oids))
+    entries))
 
 (defn index-oppilaitos
   [oid]

--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -3,7 +3,8 @@
             [kouta-indeksoija-service.indexer.kouta.common :as common]
             [kouta-indeksoija-service.indexer.tools.general :refer [Tallennettu korkeakoulutus? get-non-korkeakoulu-koodi-uri]]
             [kouta-indeksoija-service.indexer.indexable :as indexable]
-            [kouta-indeksoija-service.indexer.tools.koodisto :as koodisto]))
+            [kouta-indeksoija-service.indexer.tools.koodisto :as koodisto]
+            [clojure.string]))
 
 (def index-name "hakukohde-kouta")
 (defonce erityisopetus-koulutustyyppi "koulutustyyppi_4")
@@ -11,9 +12,9 @@
 (defn- assoc-valintaperuste
   [hakukohde valintaperuste]
   (cond-> (dissoc hakukohde :valintaperusteId)
-          (some? (:valintaperusteId hakukohde)) (assoc :valintaperuste (-> valintaperuste
-                                                                           (dissoc :metadata)
-                                                                           (common/complete-entry)))))
+    (some? (:valintaperusteId hakukohde)) (assoc :valintaperuste (-> valintaperuste
+                                                                     (dissoc :metadata)
+                                                                     (common/complete-entry)))))
 
 (defn- assoc-toteutus
   [hakukohde toteutus]
@@ -23,11 +24,11 @@
 
 (defn- assoc-sora-data
   [hakukohde sora-tiedot]
-    (assoc
-      hakukohde
-      :sora
-      (when sora-tiedot
-        (select-keys sora-tiedot [:tila]))))
+  (assoc
+   hakukohde
+   :sora
+   (when sora-tiedot
+     (select-keys sora-tiedot [:tila]))))
 
 (defn- luonnos?
   [haku-tai-hakukohde]
@@ -40,16 +41,16 @@
 (defn- alkamiskausi-kevat?
   [haku hakukohde]
   (if-some [alkamiskausi-koodi-uri (if (:kaytetaanHaunAlkamiskautta hakukohde)
-                                 (get-in haku [:metadata :koulutuksenAlkamiskausi :koulutuksenAlkamiskausiKoodiUri])
-                                 (:alkamiskausiKoodiUri hakukohde))]
+                                     (get-in haku [:metadata :koulutuksenAlkamiskausi :koulutuksenAlkamiskausiKoodiUri])
+                                     (:alkamiskausiKoodiUri hakukohde))]
     (clojure.string/starts-with? alkamiskausi-koodi-uri "kausi_k#")
     false))
 
 (defn- alkamisvuosi
   [haku hakukohde]
   (when-some [alkamisvuosi (if (:kaytetaanHaunAlkamiskautta hakukohde)
-                       (get-in haku [:metadata :koulutuksenAlkamiskausi :koulutuksenAlkamisvuosi])
-                       (:alkamisvuosi hakukohde))]
+                             (get-in haku [:metadata :koulutuksenAlkamiskausi :koulutuksenAlkamisvuosi])
+                             (:alkamisvuosi hakukohde))]
     (Integer/valueOf alkamisvuosi)))
 
 (defn- alkamiskausi-ennen-syksya-2016?
@@ -131,8 +132,12 @@
   [hakukohde koulutus]
   (let [non-korkeakoulu-koodi-uri (get-non-korkeakoulu-koodi-uri koulutus)]
     (assoc hakukohde :onkoHarkinnanvarainenKoulutus (and
-                                                      (some? non-korkeakoulu-koodi-uri)
-                                                      (nil? (koodisto/ei-harkinnanvaraisuutta non-korkeakoulu-koodi-uri))))))
+                                                     (some? non-korkeakoulu-koodi-uri)
+                                                     (nil? (koodisto/ei-harkinnanvaraisuutta non-korkeakoulu-koodi-uri))))))
+
+
+(defn- assoc-jarjestaako-urheilijan-amm-koulutusta [hakukohde toimipiste]
+  (assoc hakukohde :jarjestaaUrheilijanAmmKoulutusta (boolean (get-in toimipiste [:metadata :jarjestaaUrheilijanAmmKoulutusta]))))
 
 (defn create-index-entry
   [oid]
@@ -142,9 +147,11 @@
         koulutus       (kouta-backend/get-koulutus (:koulutusOid toteutus))
         sora-kuvaus    (kouta-backend/get-sorakuvaus (:sorakuvausId koulutus))
         valintaperusteId (:valintaperusteId hakukohde)
-        valintaperuste (when-not
-                         (clojure.string/blank? valintaperusteId)
-                         (kouta-backend/get-valintaperuste valintaperusteId))]
+        valintaperuste (when-not (clojure.string/blank? valintaperusteId)
+                         (kouta-backend/get-valintaperuste valintaperusteId))
+        jarjestyspaikkaOid (:jarjestyspaikkaOid hakukohde)
+        jarjestava-toimipiste (when-not (clojure.string/blank? jarjestyspaikkaOid)
+                                (kouta-backend/get-oppilaitoksen-osa jarjestyspaikkaOid))]
     (indexable/->index-entry oid
                              (-> hakukohde
                                  (assoc-yps haku koulutus)
@@ -154,6 +161,7 @@
                                  (assoc-koulutustyypit toteutus koulutus)
                                  (assoc-toteutus toteutus)
                                  (assoc-valintaperuste valintaperuste)
+                                 (assoc-jarjestaako-urheilijan-amm-koulutusta jarjestava-toimipiste)
                                  (assoc-hakulomake-linkki haku)))))
 
 (defn do-index

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
@@ -28,18 +28,18 @@
 (defn- oppilaitos-entry
   [organisaatio oppilaitos koulutukset]
   (cond-> (assoc-koulutusohjelmia (organisaatio-entry organisaatio) koulutukset)
-          (seq oppilaitos) (assoc :oppilaitos (-> oppilaitos
-                                                  (common/complete-entry)
-                                                  (dissoc :oid)))))
+    (seq oppilaitos) (assoc :oppilaitos (-> oppilaitos
+                                            (common/complete-entry)
+                                            (dissoc :oid)))))
 
 (defn- oppilaitoksen-osa-entry
   [organisaatio oppilaitoksen-osa]
   ; TODO oppilaitosten osat eivät voi käyttää assoc-koulutusohjelmia sillä kouta-backend/get-koulutukset-by-tarjoaja ei palauta osille mitään
   ; TODO oppilaitoksen osien pitäisi päätellä koulutusohjelmia-lkm eri reittiä: toteutukset -> koulutukset -> johtaaTutkintoon
   (cond-> (organisaatio-entry organisaatio)
-          (seq oppilaitoksen-osa) (assoc :oppilaitoksenOsa (-> oppilaitoksen-osa
-                                                               (common/complete-entry)
-                                                               (dissoc :oppilaitosOid :oid)))))
+    (seq oppilaitoksen-osa) (assoc :oppilaitoksenOsa (-> oppilaitoksen-osa
+                                                         (common/complete-entry)
+                                                         (dissoc :oppilaitosOid :oid)))))
 
 (defn- add-data-from-organisaatio-palvelu
   [organisaatio]
@@ -56,7 +56,8 @@
     (-> (oppilaitos-entry organisaatio oppilaitos koulutukset)
         (assoc :osat (->> (organisaatio-tool/get-indexable-children organisaatio)
                           (map #(oppilaitoksen-osa-entry % (find-oppilaitoksen-osa %)))
-                          (vec))))))
+                          (vec)))
+        (assoc :jarjestaaUrheilijanAmmKoulutusta (boolean (some (fn [osa] (get-in osa [:metadata :jarjestaaUrheilijanAmmKoulutusta])) oppilaitoksen-osat))))))
 
 (defn create-index-entry
   [oid]

--- a/src/kouta_indeksoija_service/rest/cas/session.clj
+++ b/src/kouta_indeksoija_service/rest/cas/session.clj
@@ -10,9 +10,9 @@
 
 (defn init-session
   [service-url jsession?]
-    (let [path (.getPath (java.net.URI. service-url))]
-      (log/info "Init cas session to service " path " @ url " service-url)
-      (map->CasSession {:service {:url service-url :path path} :session-id (atom nil) :jsession? jsession?})))
+  (let [path (.getPath (java.net.URI. service-url))]
+    (log/info "Init cas session to service " path " @ url " service-url)
+    (map->CasSession {:service {:url service-url :path path} :session-id (atom nil) :jsession? jsession?})))
 
 (defn- empty?
   [cas-session]
@@ -48,7 +48,9 @@
   ([cas-client method url opts]
    (let [method-name (upper-case (str method))]
      (log/debug method-name " => " url)
-     (let [response (cas-authenticated-request cas-client method url (assoc opts :as :json :throw-exceptions false))]
-       (handle-error url method-name response))))
+     (try
+       (let [response (cas-authenticated-request cas-client method url (assoc opts :as :json :throw-exceptions false))]
+         (handle-error url method-name response))
+       (catch Exception e (handle-error url method-name e) (throw e)))))
   ([cas-client method url]
    (cas-authenticated-request-as-json cas-client method url {})))

--- a/src/kouta_indeksoija_service/rest/kouta.clj
+++ b/src/kouta_indeksoija_service/rest/kouta.clj
@@ -4,7 +4,8 @@
            [kouta-indeksoija-service.rest.cas.session :refer [init-session cas-authenticated-request-as-json]]
            [clj-log.error-log :refer [with-error-logging]]
            [ring.util.codec :refer [url-encode]]
-           [clojure.tools.logging :as log]))
+           [clojure.tools.logging :as log]
+           [clojure.string]))
 
 (defonce cas-session (init-session (resolve-url :kouta-backend.auth-login) false))
 
@@ -39,6 +40,9 @@
 (defn get-hakukohde
   [oid]
   (get-doc "hakukohde" oid))
+
+(defn get-hakukohde-oids-by-jarjestyspaikka [oid]
+  (cas-authenticated-get-as-json (resolve-url :kouta-backend.jarjestyspaikka.hakukohde-oids oid)))
 
 (defn get-valintaperuste
   [id]

--- a/src/kouta_indeksoija_service/rest/kouta.clj
+++ b/src/kouta_indeksoija_service/rest/kouta.clj
@@ -52,6 +52,10 @@
   [oid]
   (cas-authenticated-get-as-json (resolve-url :kouta-backend.oppilaitos.oid oid) {}))
 
+(defn get-oppilaitoksen-osa
+  [oid]
+  (cas-authenticated-get-as-json (resolve-url :kouta-backend.oppilaitoksen-osa.oid oid) {}))
+
 (defn get-toteutus-list-for-koulutus
   ([koulutus-oid vainJulkaistut]
    (cas-authenticated-get-as-json (resolve-url :kouta-backend.koulutus.toteutukset koulutus-oid)
@@ -98,3 +102,4 @@
 (defn get-oppilaitoksen-osat
   [oppilaitos-oid]
   (cas-authenticated-get-as-json (resolve-url :kouta-backend.oppilaitos.osat oppilaitos-oid)))
+

--- a/src/kouta_indeksoija_service/rest/util.clj
+++ b/src/kouta_indeksoija_service/rest/util.clj
@@ -37,7 +37,8 @@
     (case status
       200 body
       404 (do (log/warn  "Got " status " from " method-name ": " url " with body " body) nil)
-          (do (log/error "Got " status " from " method-name ": " url " with response " response) nil))))
+      nil (do (log/error  "Got " status " from " method-name ": " url " with error: " (if (instance? Exception response) (.getMessage response) response)) nil)
+      (do (log/error "Got " status " from " method-name ": " url " with response " response) nil))))
 
 (defn ->json-body-with-error-handling
   [url method opts]
@@ -51,7 +52,7 @@
   ([url query-params]
    (->json-body-with-error-handling url :get {:query-params query-params}))
   ([url]
-    (get->json-body url {})))
+   (get->json-body url {})))
 
 (defn post->json-body
   ([url body content-type]

--- a/test/kouta_indeksoija_service/fixture/common_indexer_fixture.clj
+++ b/test/kouta_indeksoija_service/fixture/common_indexer_fixture.clj
@@ -27,6 +27,7 @@
 (def sorakuvaus-id "ffa8c6cf-a962-4bb2-bf61-fe8fc741fabd")
 (def oppilaitos-oid "1.2.246.562.10.10101010101")
 (def oppilaitoksen-osa-oid "1.2.246.562.10.10101010102")
+(def default-jarjestyspaikka-oid "1.2.246.562.10.67476956288")
 
 (defn no-timestamp
   [json]
@@ -137,7 +138,8 @@
                               :valintaperuste valintaperuste-id
                               :nimi "Koulutuksen 0 toteutuksen 0 hakukohde 0"
                               :muokkaaja "1.2.246.562.24.62301161440"
-                              :modified "2019-02-05T09:49:23")
+                              :modified "2019-02-05T09:49:23"
+                              :jarjestyspaikkaOid default-jarjestyspaikka-oid)
 
   (fixture/add-hakukohde-mock "1.2.246.562.20.00000000000000000002"
                               "1.2.246.562.17.00000000000000000003"
@@ -148,7 +150,9 @@
                               :muokkaaja "1.2.246.562.24.62301161440"
                               :hakuaikaAlkaa "2018-10-10T12:00"
                               :hakuaikaPaattyy "2030-11-10T12:00"
-                              :modified "2019-02-05T09:49:23")
+                              :modified "2019-02-05T09:49:23"
+                              :jarjestyspaikkaOid default-jarjestyspaikka-oid)
+
 
   (fixture/add-sorakuvaus-mock sorakuvaus-id
                                :tila "arkistoitu"
@@ -167,8 +171,14 @@
                                :muokkaaja "1.2.246.562.24.62301161440"
                                :modified "2019-02-05T09:49:23")
 
-  (fixture/add-oppilaitoksen-osa-mock "1.2.246.562.10.10101010102"
+  (fixture/add-oppilaitoksen-osa-mock oppilaitoksen-osa-oid
                                       oppilaitos-oid
+                                      :tila "julkaistu"
+                                      :muokkaaja "1.2.246.562.24.62301161440"
+                                      :modified "2019-02-05T09:49:23")
+
+  (fixture/add-oppilaitoksen-osa-mock default-jarjestyspaikka-oid
+                                      mocks/Oppilaitos1
                                       :tila "julkaistu"
                                       :muokkaaja "1.2.246.562.24.62301161440"
                                       :modified "2019-02-05T09:49:23"))

--- a/test/kouta_indeksoija_service/fixture/common_indexer_fixture.clj
+++ b/test/kouta_indeksoija_service/fixture/common_indexer_fixture.clj
@@ -23,6 +23,7 @@
 (def toteutus-oid "1.2.246.562.17.00000000000000000001")
 (def haku-oid "1.2.246.562.29.00000000000000000001")
 (def hakukohde-oid "1.2.246.562.20.00000000000000000001")
+(def hakukohde-oid2 "1.2.246.562.20.00000000000000000002")
 (def valintaperuste-id "a5e88367-555b-4d9e-aa43-0904e5ea0a13")
 (def sorakuvaus-id "ffa8c6cf-a962-4bb2-bf61-fe8fc741fabd")
 (def oppilaitos-oid "1.2.246.562.10.10101010101")
@@ -141,7 +142,7 @@
                               :modified "2019-02-05T09:49:23"
                               :jarjestyspaikkaOid default-jarjestyspaikka-oid)
 
-  (fixture/add-hakukohde-mock "1.2.246.562.20.00000000000000000002"
+  (fixture/add-hakukohde-mock hakukohde-oid2
                               "1.2.246.562.17.00000000000000000003"
                               haku-oid
                               :tila "julkaistu"

--- a/test/kouta_indeksoija_service/fixture/kouta_indexer_fixture.clj
+++ b/test/kouta_indeksoija_service/fixture/kouta_indexer_fixture.clj
@@ -94,6 +94,12 @@
     (locking KoutaFixture
       (->keywordized-json (.getKoulutuksetByTarjoajat KoutaFixture oids)))))
 
+(defn mock-get-hakukohde-oids-by-jarjestyspaikka
+  [oid]
+  (let [oids (str oid "," oid "1," oid "2," oid "3")]
+    (locking KoutaFixture
+      (->keywordized-json (.getHakukohdeOidsByJarjestyspaikat KoutaFixture oids)))))
+
 (defn add-toteutus-mock
   [oid koulutusOid & {:as params}]
   (let [toteutus (merge default-toteutus-map {:organisaatio Oppilaitos1} params {:koulutusOid koulutusOid})]
@@ -386,6 +392,9 @@
 
                  kouta-indeksoija-service.rest.kouta/get-koulutukset-by-tarjoaja
                  kouta-indeksoija-service.fixture.kouta-indexer-fixture/mock-get-koulutukset-by-tarjoaja
+
+                 kouta-indeksoija-service.rest.kouta/get-hakukohde-oids-by-jarjestyspaikka
+                 kouta-indeksoija-service.fixture.kouta-indexer-fixture/mock-get-hakukohde-oids-by-jarjestyspaikka
 
                  kouta-indeksoija-service.rest.kouta/list-koulutus-oids-by-sorakuvaus
                  kouta-indeksoija-service.fixture.kouta-indexer-fixture/mock-list-koulutus-oids-by-sorakuvaus

--- a/test/kouta_indeksoija_service/fixture/kouta_indexer_fixture.clj
+++ b/test/kouta_indeksoija_service/fixture/kouta_indexer_fixture.clj
@@ -186,8 +186,8 @@
 
 (defn add-oppilaitoksen-osa-mock
   [oid oppilaitosOid & {:as params}]
-  (let [oppilaitosen-osa (merge default-oppilaitoksen-osa-map {:organisaatio Oppilaitos1} params {:oppilaitosOid oppilaitosOid})]
-    (.addOppilaitoksenOsa KoutaFixture oid (->java-map oppilaitosen-osa))))
+  (let [oppilaitoksen-osa (merge default-oppilaitoksen-osa-map {:organisaatio Oppilaitos1} params {:oppilaitosOid oppilaitosOid})]
+    (.addOppilaitoksenOsa KoutaFixture oid (->java-map oppilaitoksen-osa))))
 
 (defn update-oppilaitoksen-osa-mock
   [oid & {:as params}]
@@ -301,13 +301,13 @@
 
 (defn toimipiste-children
   [oids]
-    (map #(-> {}
-              (assoc :oid %)
-              (assoc :status "AKTIIVINEN")
-              (assoc :kotipaikkaUri "kunta_091")
-              (assoc :children [])
-              (assoc :nimi {:fi (str "Toimipiste fi " %)
-                            :sv (str "Toimipiste sv " %)})) oids))
+  (map #(-> {}
+            (assoc :oid %)
+            (assoc :status "AKTIIVINEN")
+            (assoc :kotipaikkaUri "kunta_091")
+            (assoc :children [])
+            (assoc :nimi {:fi (str "Toimipiste fi " %)
+                          :sv (str "Toimipiste sv " %)})) oids))
 
 (defn mocked-hierarkia-default-entity [oid]
   (println "mocked hierarkia base entity for oid " oid)
@@ -324,8 +324,7 @@
                     :status "AKTIIVINEN"
                     :aliOrganisaatioMaara 3
                     :organisaatiotyypit ["organisaatiotyyppi_03"]
-                    :children (toimipiste-children ["1.2.246.562.10.777777777991" "1.2.246.562.10.777777777992" "1.2.246.562.10.777777777993"])
-                    }]})
+                    :children (toimipiste-children ["1.2.246.562.10.777777777991" "1.2.246.562.10.777777777992" "1.2.246.562.10.777777777993"])}]})
 
 (defn mock-organisaatio-hierarkia-v4
   [oid]
@@ -363,6 +362,9 @@
 
                  kouta-indeksoija-service.rest.kouta/get-oppilaitos
                  kouta-indeksoija-service.fixture.kouta-indexer-fixture/mock-get-oppilaitos
+
+                 kouta-indeksoija-service.rest.kouta/get-oppilaitoksen-osa
+                 kouta-indeksoija-service.fixture.kouta-indexer-fixture/mock-get-oppilaitoksen-osa
 
                  kouta-indeksoija-service.rest.kouta/get-hakutiedot-for-koulutus
                  kouta-indeksoija-service.fixture.kouta-indexer-fixture/mock-get-hakutiedot-for-koulutus

--- a/test/kouta_indeksoija_service/indexer/kouta_indexer_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_indexer_test.clj
@@ -129,6 +129,14 @@
        (is (= mocks/Oppilaitos1 (:oid (get-doc oppilaitos-search/index-name mocks/Oppilaitos1))))
        (is (= koulutus-oid (:oid (get-doc koulutus-search/index-name koulutus-oid))))))))
 
+(deftest index-oppilaitoksen-osa
+  (fixture/with-mocked-indexing
+    (testing "Indexer should index hakukohde when indexing oppilaitoksen osa that is set as järjestyspaikka on that hakukohde"
+      (with-redefs [kouta-indeksoija-service.rest.organisaatio/get-hierarkia-for-oid-without-parents mocks/mock-organisaatio]
+        (check-all-nil)
+        (i/index-oppilaitokset [default-jarjestyspaikka-oid])
+        (is (= "1.2.246.562.20.00000000000000000002" (:oid (get-doc hakukohde/index-name "1.2.246.562.20.00000000000000000002"))))))))
+
 (deftest index-organisaatio-no-oppilaitokset-test
   (fixture/with-mocked-indexing
    (with-redefs [kouta-indeksoija-service.rest.kouta/get-koulutukset-by-tarjoaja (fn [oid] (throw (Exception. (str "I was called with [" oid "]"))))
@@ -246,7 +254,6 @@
 
 (defonce koulutus-oid2   "1.2.246.562.13.00000000000000000099")
 (defonce toteutus-oid2   "1.2.246.562.17.00000000000000000099")
-(defonce hakukohde-oid2  "1.2.246.562.20.00000000000000000002")
 (defonce oppilaitos-oid2 "1.2.246.562.10.77777777799")
 
 (deftest index-all-hakukohteet-test

--- a/test/kouta_indeksoija_service/indexer/kouta_indexer_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_indexer_test.clj
@@ -15,8 +15,11 @@
             [kouta-indeksoija-service.elastic.tools :refer [get-doc]]
             [kouta-indeksoija-service.fixture.kouta-indexer-fixture :as fixture]
             [kouta-indeksoija-service.test-tools :refer [parse compare-json debug-pretty]]
-            [clj-test-utils.elasticsearch-mock-utils :refer :all]
+            [kouta-indeksoija-service.indexer.cache.hierarkia]
+            [kouta-indeksoija-service.rest.organisaatio]
+            [kouta-indeksoija-service.rest.kouta]
             [kouta-indeksoija-service.fixture.external-services :as mocks]
+            [clj-test-utils.elasticsearch-mock-utils :refer :all]
             [mocks.externals-mock :as mock]))
 
 (use-fixtures :each fixture/indices-fixture)

--- a/test/resources/kouta/kouta-hakukohde-result.json
+++ b/test/resources/kouta/kouta-hakukohde-result.json
@@ -448,5 +448,6 @@
   },
   "onkoHarkinnanvarainenKoulutus": false,
   "koulutustyypit": ["koulutustyyppi_01", "koulutustyyppi_02"],
-  "externalId": "3344556677"
+  "externalId": "3344556677",
+  "jarjestaaUrheilijanAmmKoulutusta": false
 }

--- a/test/resources/kouta/kouta-oppilaitos-result.json
+++ b/test/resources/kouta/kouta-oppilaitos-result.json
@@ -119,7 +119,8 @@
               "fi": "http://www.oppilaitos.fi",
               "sv": "http://www.oppilaitos.sv"
             }
-          }
+          },
+          "jarjestaaUrheilijanAmmKoulutusta": false
         }
       }
     },
@@ -351,5 +352,6 @@
       "fi": "kunta_091 nimi fi",
       "sv": "kunta_091 nimi sv"
     }
-  }
+  },
+  "jarjestaaUrheilijanAmmKoulutusta": false
 }


### PR DESCRIPTION
Tikettiin liittyen:
- Indeksoidaan oppilaitoksen osalle tallennettu "jarjestaaUrheilijanAmmKoulutusta" myös oppilaitokselle (jos ainakin yhdellä osalla true, myös oppilaitoksella true)
- Indeksoidaan hakukohteelle "jarjestaaUrheilijanAmmKoulutusta"-tieto sille valitulta järjestyspaikalta.

Pari yleisempää parannusta:
- Vaihdettu lokaalin kehityksen portti -> 8100. Aiempi 3000 konfliktoi kouta-ui:n dev-serverin kanssa.
- Parannettu epäonnistuneen HTTP-pyynnön logitusta jos lentää poikkeus (esim. "Connection Refused")
- Poistettu tarpeettomaksi jäänyt CORS-kierto