### PR TITLE
KTO-1408: TUVA-koulutustyyppisuodattimen hierarkia

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
  "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject kouta-indeksoija-service "9.1.0-SNAPSHOT"
+(defproject kouta-indeksoija-service "9.2.0-SNAPSHOT"
   :description "Kouta-indeksoija"
   :repositories [["releases" {:url "https://artifactory.opintopolku.fi/artifactory/oph-sade-release-local"
                               :username :env/artifactory_username

--- a/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
@@ -55,7 +55,7 @@
                  :let [hakutieto (search-tool/get-toteutuksen-julkaistut-hakutiedot hakutiedot toteutus)]
                  :let [toteutus-metadata (:metadata toteutus)]
                  :let [opetus (get-in toteutus [:metadata :opetus])]]
-             (search-tool/hit :koulutustyypit            (search-tool/deduce-koulutustyypit koulutus (:ammatillinenPerustutkintoErityisopetuksena toteutus-metadata))
+             (search-tool/hit :koulutustyypit            (search-tool/deduce-koulutustyypit koulutus toteutus-metadata)
                               :opetuskieliUrit           (:opetuskieliKoodiUrit opetus)
                               :tarjoajat                 (:tarjoajat toteutus)
                               :oppilaitos                oppilaitos
@@ -116,7 +116,7 @@
         :hakutiedot (get-search-hakutiedot hakutieto)
         :toteutus-organisaationimi (remove nil? (distinct (map :nimi (flatten (:tarjoajat toteutus)))))
         :opetuskieliUrit (:opetuskieliKoodiUrit opetus)
-        :koulutustyypit (search-tool/deduce-koulutustyypit koulutus (:ammatillinenPerustutkintoErityisopetuksena toteutus-metadata))
+        :koulutustyypit (search-tool/deduce-koulutustyypit koulutus toteutus-metadata)
         :kuva (:logo oppilaitos)
         :nimi (:nimi oppilaitos)
         :onkoTuleva false

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos_search.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos_search.clj
@@ -65,7 +65,7 @@
   (let [hakutieto (search-tool/get-toteutuksen-julkaistut-hakutiedot hakutiedot toteutus)
         toteutus-metadata (:metadata toteutus)
         opetus (get-in toteutus [:metadata :opetus])]
-    (search-tool/hit :koulutustyypit            (search-tool/deduce-koulutustyypit koulutus (:ammatillinenPerustutkintoErityisopetuksena toteutus-metadata))
+    (search-tool/hit :koulutustyypit            (search-tool/deduce-koulutustyypit koulutus toteutus-metadata)
                      :opetuskieliUrit           (get-in toteutus [:metadata :opetus :opetuskieliKoodiUrit])
                      :tarjoajat                 (tarjoaja-organisaatiot oppilaitos (:tarjoajat toteutus))
                      :tarjoajaOids              (:tarjoajat toteutus)
@@ -129,7 +129,7 @@
                               :hakutiedot (get-search-hakutiedot hakutieto)
                               :toteutus-organisaationimi (remove nil? (distinct (map :nimi tarjoajat)))
                               :opetuskieliUrit (get-in toteutus [:metadata :opetus :opetuskieliKoodiUrit])
-                              :koulutustyypit (search-tool/deduce-koulutustyypit koulutus (:ammatillinenPerustutkintoErityisopetuksena toteutus-metadata))
+                              :koulutustyypit (search-tool/deduce-koulutustyypit koulutus toteutus-metadata)
                               :kuva (:teemakuva toteutus)
                               :nimi (get-esitysnimi toteutus)
                               :onkoTuleva false

--- a/src/kouta_indeksoija_service/indexer/tools/general.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/general.clj
@@ -36,6 +36,14 @@
   [koulutus]
   (= "telma" (:koulutustyyppi koulutus)))
 
+(defn vapaa-sivistystyo-opistovuosi?
+  [koulutus]
+  (= "vapaa-sivistystyo-opistovuosi" (:koulutustyyppi koulutus)))
+
+(defn vapaa-sivistystyo-muu?
+  [koulutus]
+  (= "vapaa-sivistystyo-muu" (:koulutustyyppi koulutus)))
+
 (defn any-ammatillinen?
   [koulutus]
   (or (ammatillinen? koulutus) (amm-osaamisala? koulutus) (amm-tutkinnon-osa? koulutus)))

--- a/src/kouta_indeksoija_service/indexer/tools/search.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/search.clj
@@ -1,6 +1,6 @@
 (ns kouta-indeksoija-service.indexer.tools.search
   (:require [clojure.edn :as edn]
-            [kouta-indeksoija-service.indexer.tools.general :refer [asiasana->lng-value-map amm-osaamisala? amm-tutkinnon-osa? any-ammatillinen? ammatillinen? korkeakoulutus? lukio? tuva? telma? julkaistu? get-non-korkeakoulu-koodi-uri set-hakukohde-tila-by-related-haku]]
+            [kouta-indeksoija-service.indexer.tools.general :refer [asiasana->lng-value-map amm-osaamisala? amm-tutkinnon-osa? any-ammatillinen? ammatillinen? korkeakoulutus? lukio? tuva? telma? julkaistu? vapaa-sivistystyo-opistovuosi? vapaa-sivistystyo-muu? get-non-korkeakoulu-koodi-uri set-hakukohde-tila-by-related-haku]]
             [kouta-indeksoija-service.indexer.tools.koodisto :as koodisto]
             [kouta-indeksoija-service.rest.koodisto :refer [extract-versio get-koodi-nimi-with-cache]]
             [kouta-indeksoija-service.indexer.tools.tyyppi :refer [remove-uri-version koodi-arvo oppilaitostyyppi-uri-to-tyyppi]]
@@ -278,8 +278,8 @@
   [koulutus]
   (let [koulutustyyppikoodit (koulutustyyppi-koodi-urit koulutus)
         koulutustyypit-without-erityisopetus (filter #(not= % amm-perustutkinto-erityisopetuksena-koulutustyyppi) koulutustyyppikoodit)
-        internal-koulutystyyppi (vector (:koulutustyyppi koulutus))
-        result (concat koulutustyypit-without-erityisopetus internal-koulutystyyppi)]
+        internal-koulutustyyppi (vector (:koulutustyyppi koulutus))
+        result (concat koulutustyypit-without-erityisopetus internal-koulutustyyppi)]
     (if (korkeakoulutus? koulutus)
       (concat result (get-korkeakoulutus-koulutustyyppi koulutus))
       result)))
@@ -293,7 +293,12 @@
          ]
    (cond
      amm-erityisopetuksena? [amm-perustutkinto-erityisopetuksena-koulutustyyppi koulutustyyppi]
-     (tuva? koulutus) [(if tuva-erityisopetuksena? "tuva-erityisopetus" "tuva-normal") koulutustyyppi]
+     (and (tuva? koulutus) (not= toteutus-metadata nil)) [(if tuva-erityisopetuksena? "tuva-erityisopetus" "tuva-normal") koulutustyyppi]
+     (amm-osaamisala? koulutus) [koulutustyyppi "amm-muu"]
+     (amm-tutkinnon-osa? koulutus) [koulutustyyppi "amm-muu"]
+     (telma? koulutus) [koulutustyyppi "amm-muu"]
+     (vapaa-sivistystyo-opistovuosi? koulutus) [koulutustyyppi "vapaa-sivistystyo"]
+     (vapaa-sivistystyo-muu? koulutus) [koulutustyyppi "vapaa-sivistystyo"]
      :else (get-koulutustyypit-from-koulutus-koodi koulutus))))
   ([koulutus]
    (deduce-koulutustyypit koulutus nil)))

--- a/src/kouta_indeksoija_service/indexer/tools/search.clj
+++ b/src/kouta_indeksoija_service/indexer/tools/search.clj
@@ -285,12 +285,18 @@
       result)))
 
 (defn deduce-koulutustyypit
-  ([koulutus ammatillinen-perustutkinto-erityisopetuksena?]
-   (if ammatillinen-perustutkinto-erityisopetuksena?
-     (concat [amm-perustutkinto-erityisopetuksena-koulutustyyppi] (vector (:koulutustyyppi koulutus)))
-     (get-koulutustyypit-from-koulutus-koodi koulutus)))
+  ([koulutus toteutus-metadata]
+   (let [
+         koulutustyyppi (:koulutustyyppi koulutus)
+         amm-erityisopetuksena? (:ammatillinenPerustutkintoErityisopetuksena toteutus-metadata)
+         tuva-erityisopetuksena? (:jarjestetaanErityisopetuksena toteutus-metadata)
+         ]
+   (cond
+     amm-erityisopetuksena? [amm-perustutkinto-erityisopetuksena-koulutustyyppi koulutustyyppi]
+     (tuva? koulutus) [(if tuva-erityisopetuksena? "tuva-erityisopetus" "tuva-normal") koulutustyyppi]
+     :else (get-koulutustyypit-from-koulutus-koodi koulutus))))
   ([koulutus]
-   (deduce-koulutustyypit koulutus false)))
+   (deduce-koulutustyypit koulutus nil)))
 
 (defn- get-toteutuksen-hakutieto
   [hakutiedot t]

--- a/test/kouta_indeksoija_service/indexer/search_tests/kouta_koulutus_search_test.clj
+++ b/test/kouta_indeksoija_service/indexer/search_tests/kouta_koulutus_search_test.clj
@@ -18,7 +18,7 @@
             result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus toteutus-metadata)]
         (is (= ["koulutustyyppi_26" "amm"] result))))))
 
-(deftest add-only-erityisopetus-koulutustyyppi-koodi
+(deftest add-amm-erityisopetus-koulutustyyppi-koodi
   (testing "If ammatillinen perustutkinto erityisopetuksena, add only erityisopetus koulutustyyppi koodi"
     (with-redefs [kouta-indeksoija-service.rest.koodisto/list-alakoodi-nimet-with-cache mock-koodisto-koulutustyyppi]
       (let [koulutus {:koulutustyyppi "amm"}
@@ -26,21 +26,49 @@
             result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus toteutus-metadata)]
         (is (= ["koulutustyyppi_4" "amm"] result))))))
 
-(deftest add-only-erityisopetus-koulutustyyppi-koodi
-  (testing "If tuva without erityisopetus, add tuva-normal koulutustyyppi"
-    (with-redefs [kouta-indeksoija-service.rest.koodisto/list-alakoodi-nimet-with-cache mock-koodisto-koulutustyyppi]
+(deftest add-tuva-normal-koulutustyyppi
+  (testing "If tuva without erityisopetus, add 'tuva-normal' koulutustyyppi"
       (let [koulutus {:koulutustyyppi "tuva"}
             toteutus-metadata {:jarjestetaanErityisopetuksena false}
             result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus toteutus-metadata)]
-        (is (= ["tuva-normal" "tuva"] result))))))
+        (is (= ["tuva-normal" "tuva"] result)))))
 
-(deftest add-only-erityisopetus-koulutustyyppi-koodi
+(deftest add-tuva-erityisopetus-koulutustyyppi
   (testing "If tuva erityisopetuksena, add 'tuva-erityisopetus' koulutustyyppi"
-    (with-redefs [kouta-indeksoija-service.rest.koodisto/list-alakoodi-nimet-with-cache mock-koodisto-koulutustyyppi]
       (let [koulutus {:koulutustyyppi "tuva"}
             toteutus-metadata {:jarjestetaanErityisopetuksena true}
             result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus toteutus-metadata)]
-        (is (= ["tuva-erityisopetus" "tuva"] result))))))
+        (is (= ["tuva-erityisopetus" "tuva"] result)))))
+
+(deftest add-vapaa-sivistystyo-koulutustyyppi-when-opistovuosi
+  (testing "If vapaa-sivistystyo-opistovuosi, add 'vapaa-sivistystyo' koulutustyyppi"
+      (let [koulutus {:koulutustyyppi "vapaa-sivistystyo-opistovuosi"}
+            result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus)]
+        (is (= ["vapaa-sivistystyo-opistovuosi" "vapaa-sivistystyo"] result)))))
+
+(deftest add-vapaa-sivistystyo-koulutustyyppi-when-muu
+  (testing "If vapaa-sivistystyo-muu, add 'vapaa-sivistystyo' koulutustyyppi"
+      (let [koulutus {:koulutustyyppi "vapaa-sivistystyo-muu"}
+            result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus)]
+        (is (= ["vapaa-sivistystyo-muu" "vapaa-sivistystyo"] result)))))
+
+(deftest add-amm-muu-koulutustyyppi-when-telma
+  (testing "If telma, add 'amm-muu' koulutustyyppi"
+    (let [koulutus {:koulutustyyppi "telma"}
+          result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus)]
+      (is (= ["telma" "amm-muu"] result)))))
+
+(deftest add-amm-muu-koulutustyyppi-when-tutkinnon-osa
+  (testing "If amm-tutkinnon-osa, add 'amm-muu' koulutustyyppi"
+    (let [koulutus {:koulutustyyppi "amm-tutkinnon-osa"}
+          result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus)]
+      (is (= ["amm-tutkinnon-osa" "amm-muu"] result)))))
+
+(deftest add-amm-muu-koulutustyyppi-when-osaamisala
+  (testing "If amm-osaamisala, add 'amm-muu' koulutustyyppi"
+    (let [koulutus {:koulutustyyppi "amm-osaamisala"}
+          result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus)]
+      (is (= ["amm-osaamisala" "amm-muu"] result)))))
 
 (deftest hakutieto-tools-test
   (let [hakuaika1     {:alkaa "2031-04-02T12:00" :paattyy "2031-05-02T12:00"}

--- a/test/kouta_indeksoija_service/indexer/search_tests/kouta_koulutus_search_test.clj
+++ b/test/kouta_indeksoija_service/indexer/search_tests/kouta_koulutus_search_test.clj
@@ -14,17 +14,33 @@
   (testing "If not ammatillinen perustutkinto erityisopetuksena, filter out erityisopetus koulutustyyppi from koodisto response"
     (with-redefs [kouta-indeksoija-service.rest.koodisto/list-alakoodi-nimet-with-cache mock-koodisto-koulutustyyppi]
       (let [koulutus {:koulutustyyppi "amm"}
-            ammatillinen-perustutkinto-erityisopetuksena? false
-            result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus ammatillinen-perustutkinto-erityisopetuksena?)]
+            toteutus-metadata {:ammatillinenPerustutkintoErityisopetuksena false}
+            result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus toteutus-metadata)]
         (is (= ["koulutustyyppi_26" "amm"] result))))))
 
 (deftest add-only-erityisopetus-koulutustyyppi-koodi
   (testing "If ammatillinen perustutkinto erityisopetuksena, add only erityisopetus koulutustyyppi koodi"
     (with-redefs [kouta-indeksoija-service.rest.koodisto/list-alakoodi-nimet-with-cache mock-koodisto-koulutustyyppi]
       (let [koulutus {:koulutustyyppi "amm"}
-            ammatillinen-perustutkinto-erityisopetuksena? true
-            result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus ammatillinen-perustutkinto-erityisopetuksena?)]
+            toteutus-metadata {:ammatillinenPerustutkintoErityisopetuksena true}
+            result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus toteutus-metadata)]
         (is (= ["koulutustyyppi_4" "amm"] result))))))
+
+(deftest add-only-erityisopetus-koulutustyyppi-koodi
+  (testing "If tuva without erityisopetus, add tuva-normal koulutustyyppi"
+    (with-redefs [kouta-indeksoija-service.rest.koodisto/list-alakoodi-nimet-with-cache mock-koodisto-koulutustyyppi]
+      (let [koulutus {:koulutustyyppi "tuva"}
+            toteutus-metadata {:jarjestetaanErityisopetuksena false}
+            result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus toteutus-metadata)]
+        (is (= ["tuva-normal" "tuva"] result))))))
+
+(deftest add-only-erityisopetus-koulutustyyppi-koodi
+  (testing "If tuva erityisopetuksena, add 'tuva-erityisopetus' koulutustyyppi"
+    (with-redefs [kouta-indeksoija-service.rest.koodisto/list-alakoodi-nimet-with-cache mock-koodisto-koulutustyyppi]
+      (let [koulutus {:koulutustyyppi "tuva"}
+            toteutus-metadata {:jarjestetaanErityisopetuksena true}
+            result (kouta-indeksoija-service.indexer.tools.search/deduce-koulutustyypit koulutus toteutus-metadata)]
+        (is (= ["tuva-erityisopetus" "tuva"] result))))))
 
 (deftest hakutieto-tools-test
   (let [hakuaika1     {:alkaa "2031-04-02T12:00" :paattyy "2031-05-02T12:00"}

--- a/test/resources/search/koulutus-search-item-osaamisala.json
+++ b/test/resources/search/koulutus-search-item-osaamisala.json
@@ -52,6 +52,7 @@
         "kansallinenkoulutusluokitus2016koulutusalataso2_02"
       ],
       "koulutustyypit": [
+        "amm-muu",
         "amm-osaamisala"
       ],
       "kuva": "https://testi.fi/oppilaitos-logo/oid/logo.png",
@@ -80,6 +81,7 @@
       ],
       "hakutiedot": [],
       "koulutustyypit": [
+        "amm-muu",
         "amm-osaamisala"
       ],
       "terms": {

--- a/test/resources/search/koulutus-search-item-tutkinnon-osa.json
+++ b/test/resources/search/koulutus-search-item-tutkinnon-osa.json
@@ -69,6 +69,7 @@
         "kansallinenkoulutusluokitus2016koulutusalataso2_02"
       ],
       "koulutustyypit": [
+        "amm-muu",
         "amm-tutkinnon-osa"
       ],
       "koulutusOid": "1.2.246.562.13.00000000000000000096",
@@ -102,6 +103,7 @@
       ],
       "hakutiedot": [],
       "koulutustyypit": [
+        "amm-muu",
         "amm-tutkinnon-osa"
       ],
       "terms": {

--- a/test/resources/search/oppilaitos-search-item-koulutus-and-toteutukset.json
+++ b/test/resources/search/oppilaitos-search-item-koulutus-and-toteutukset.json
@@ -354,6 +354,7 @@
         "maakunta_01"
       ],
       "koulutustyypit": [
+        "amm-muu",
         "amm-osaamisala"
       ],
       "terms": {
@@ -425,6 +426,7 @@
         "maakunta_01"
       ],
       "koulutustyypit": [
+        "amm-muu",
         "amm-tutkinnon-osa"
       ],
       "terms": {
@@ -897,6 +899,7 @@
         "maakunta_01"
       ],
       "koulutustyypit": [
+        "amm-muu",
         "amm-osaamisala"
       ],
       "koulutus_organisaationimi": {
@@ -961,6 +964,7 @@
         "maakunta_01"
       ],
       "koulutustyypit": [
+        "amm-muu",
         "amm-tutkinnon-osa"
       ],
       "koulutus_organisaationimi": {


### PR DESCRIPTION
Koulutustyyppi-suodattimeen hierarkia:
- tuva
  - tuva-normal
  - tuva-erityisopetus
 
Lisäksi siirretty muidenkin ylätason koulutustyyppien ("amm-muu", "vapaa-sivistystyo") muodostaminen konfo-backendistä indeksoijaan.