### PR TITLE
Kto 1355 yhteystiedot organisaatiopalvelusta

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -80,8 +80,8 @@
                    :injections [(require 'pjstadig.humane-test-output)
                                 (pjstadig.humane-test-output/activate!)]}
              :test {:env {:test "true"} :dependencies [[cloud.localstack/localstack-utils "0.1.22"]
-                                                       [fi.oph.kouta/kouta-backend "6.20.0-SNAPSHOT"]
-                                                       [fi.oph.kouta/kouta-backend "6.20.0-SNAPSHOT" :classifier "tests"]
+                                                       [fi.oph.kouta/kouta-backend "6.20.3-SNAPSHOT"]
+                                                       [fi.oph.kouta/kouta-backend "6.20.3-SNAPSHOT" :classifier "tests"]
                                                        [fi.oph.kouta/kouta-common "2.6.0-SNAPSHOT" :classifier "tests"]
                                                        [oph/clj-test-utils "0.3.0-SNAPSHOT"]]
                     :resource-paths ["test_resources"]
@@ -93,8 +93,8 @@
              :ci-test {:env {:test "true"}
                        :dependencies [[ring/ring-mock "0.3.2"]
                                       [cloud.localstack/localstack-utils "0.1.22"]
-                                      [fi.oph.kouta/kouta-backend "6.20.0-SNAPSHOT"]
-                                      [fi.oph.kouta/kouta-backend "6.20.0-SNAPSHOT" :classifier "tests"]
+                                      [fi.oph.kouta/kouta-backend "6.20.3-SNAPSHOT"]
+                                      [fi.oph.kouta/kouta-backend "6.20.3-SNAPSHOT" :classifier "tests"]
                                       [fi.oph.kouta/kouta-common "2.6.0-SNAPSHOT" :classifier "tests"]
                                       [oph/clj-test-utils "0.3.0-SNAPSHOT"]]
                        :jvm-opts ["-Dlog4j.configurationFile=dev_resources/log4j2.properties"

--- a/project.clj
+++ b/project.clj
@@ -81,8 +81,8 @@
                    :injections [(require 'pjstadig.humane-test-output)
                                 (pjstadig.humane-test-output/activate!)]}
              :test {:env {:test "true"} :dependencies [[cloud.localstack/localstack-utils "0.1.22"]
-                                                       [fi.oph.kouta/kouta-backend "6.21.0-SNAPSHOT"]
-                                                       [fi.oph.kouta/kouta-backend "6.21.0-SNAPSHOT" :classifier "tests"]
+                                                       [fi.oph.kouta/kouta-backend "6.21.2-SNAPSHOT"]
+                                                       [fi.oph.kouta/kouta-backend "6.21.2-SNAPSHOT" :classifier "tests"]
                                                        [fi.oph.kouta/kouta-common "2.7.0-SNAPSHOT" :classifier "tests"]
                                                        [oph/clj-test-utils "0.3.0-SNAPSHOT"]]
                     :resource-paths ["test_resources"]
@@ -94,8 +94,8 @@
              :ci-test {:env {:test "true"}
                        :dependencies [[ring/ring-mock "0.3.2"]
                                       [cloud.localstack/localstack-utils "0.1.22"]
-                                      [fi.oph.kouta/kouta-backend "6.21.0-SNAPSHOT"]
-                                      [fi.oph.kouta/kouta-backend "6.21.0-SNAPSHOT" :classifier "tests"]
+                                      [fi.oph.kouta/kouta-backend "6.21.2-SNAPSHOT"]
+                                      [fi.oph.kouta/kouta-backend "6.21.2-SNAPSHOT" :classifier "tests"]
                                       [fi.oph.kouta/kouta-common "2.7.0-SNAPSHOT" :classifier "tests"]
                                       [oph/clj-test-utils "0.3.0-SNAPSHOT"]]
                        :jvm-opts ["-Dlog4j.configurationFile=dev_resources/log4j2.properties"

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
@@ -67,7 +67,7 @@
         postinumero_uri (create-kielistetty-yhteystieto osoitetieto :postinumeroUri languages)
         postinumero (zipmap
                       (keys postinumero_uri)
-                      (map #(clojure.string/replace % #"posti_" "") (vals postinumero_uri)))
+                      (map #(re-find #"\d{5}" %) (vals postinumero_uri)))
         postitoimipaikka (create-kielistetty-yhteystieto osoitetieto :postitoimipaikka languages)
         capitalized_postitoimipaikka (zipmap
                                        (keys postitoimipaikka)

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
@@ -105,6 +105,30 @@
       :postiosoiteStr (create-kielistetty-osoite-str postiosoitteet ulkomainen_posti_en languages)
       :kayntiosoiteStr (create-kielistetty-osoite-str kayntiosoitteet ulkomainen_kaynti_en languages)}]))
 
+(defn create-osoite-str-for-hakijapalvelut
+  [katuosoite-map postinumero toimipaikka]
+  (let [toimipaikat (select-keys toimipaikka (keys katuosoite-map))
+        toimipaikat-with-default (into {} (for [[k, v] katuosoite-map]
+                                            (if (not (contains? toimipaikat k))
+                                              [k (:fi toimipaikat)]
+                                              [k (k toimipaikat)])))
+        capitalized_toimipaikat (zipmap
+                                  (keys toimipaikat-with-default)
+                                  (map #(clojure.string/capitalize %) (vals toimipaikat-with-default)))]
+   (merge-with #(str %1 " " %2)
+               (into {} (for [[k v] katuosoite-map] [k (str v ", " postinumero)]))
+               capitalized_toimipaikat)))
+
+(defn add-osoite-str-to-yhteystiedot
+  [yhteystiedot-from-oppilaitos-metadata osoitetyyppi]
+  (if-let [postiosoite (get-in yhteystiedot-from-oppilaitos-metadata [osoitetyyppi])]
+    (let [postinumerokoodiuri (get-in postiosoite [:postinumeroKoodiUri])
+          postinumero (re-find #"\d{5}" postinumerokoodiuri)
+          postitoimipaikka (get-koodi-nimi-with-cache postinumerokoodiuri)
+          postiosoite-str (create-osoite-str-for-hakijapalvelut (get-in postiosoite [:osoite]) postinumero (:nimi postitoimipaikka))]
+      (assoc yhteystiedot-from-oppilaitos-metadata :postiosoiteStr postiosoite-str))
+    yhteystiedot-from-oppilaitos-metadata))
+
 (defn- add-data-from-organisaatio-palvelu
   [organisaatio]
   (let [org-from-organisaatio-palvelu (organisaatio-client/get-by-oid-cached (:oid organisaatio))
@@ -119,7 +143,13 @@
         oppilaitos (or (kouta-backend/get-oppilaitos oppilaitos-oid) {})
         oppilaitos-from-organisaatiopalvelu (organisaatio-client/get-by-oid-cached oppilaitos-oid)
         yhteystiedot (parse-yhteystiedot oppilaitos-from-organisaatiopalvelu languages)
-        oppilaitos-metadata (assoc (get-in oppilaitos [:metadata]) :yhteystiedot yhteystiedot)
+        hakijapalveluiden-yhteystiedot (-> (get-in (get-in oppilaitos [:metadata]) [:hakijapalveluidenYhteystiedot])
+                                           (add-osoite-str-to-yhteystiedot :postiosoite)
+                                           (add-osoite-str-to-yhteystiedot :kayntiosoite))
+        oppilaitos-metadata (assoc
+                              (get-in oppilaitos [:metadata])
+                              :yhteystiedot yhteystiedot
+                              :hakijapalveluidenYhteystiedot hakijapalveluiden-yhteystiedot)
         enriched-oppilaitos (assoc oppilaitos :metadata oppilaitos-metadata)
         oppilaitoksen-osat (map #(add-data-from-organisaatio-palvelu %) (kouta-backend/get-oppilaitoksen-osat oppilaitos-oid))
         koulutukset (kouta-backend/get-koulutukset-by-tarjoaja (:oid organisaatio))

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
@@ -40,20 +40,63 @@
     (seq oppilaitoksen-osa) (assoc :oppilaitoksenOsa (-> oppilaitoksen-osa
                                                          (common/complete-entry)
                                                          (dissoc :oppilaitosOid :oid)))))
+(defn create-kielistetty-yhteystieto
+  [yhteystieto yhteystieto-name languages]
+  (into {} (for [lang languages
+                 :let [result (yhteystieto-name
+                                (first
+                                  (filter
+                                    (fn [yhteystieto-map]
+                                      (re-find (re-pattern lang) (:kieli yhteystieto-map)))
+                                    yhteystieto)))]
+                 :when (not (nil? result))]
+             [(keyword lang) result])))
+
+(defn create-kielistetty-osoitetieto
+  [osoitetieto languages]
+  {:osoite (create-kielistetty-yhteystieto osoitetieto :osoite languages)
+   :postinumeroKoodiUri (:postinumeroUri (first (filter (fn [os] (get-in os [:postinumeroUri])) osoitetieto)))})
+
+(defn parse-yhteystiedot
+  [response languages]
+  (let [yhteystiedot (:yhteystiedot response)
+        sahkopostit (filter (fn [yhteystieto] (get-in yhteystieto [:email])) yhteystiedot)
+        puhelinnumerot (filter (fn [yhteystieto] (= "puhelin" (get-in yhteystieto [:tyyppi]))) yhteystiedot)
+        postiosoitteet (filter (fn [yhteystieto] (= "posti" (get-in yhteystieto [:osoiteTyyppi]))) yhteystiedot)
+        kayntiosoitteet (filter (fn [yhteystieto] (= "kaynti" (get-in yhteystieto [:osoiteTyyppi]))) yhteystiedot)]
+  [{:nimi (:nimi response)
+   :sahkoposti (create-kielistetty-yhteystieto sahkopostit :email languages)
+   :puhelinnumero (create-kielistetty-yhteystieto puhelinnumerot :numero languages)
+   :postiosoite (create-kielistetty-osoitetieto postiosoitteet languages)
+   :kayntiosoite (create-kielistetty-osoitetieto kayntiosoitteet languages)
+   }]))
 
 (defn- add-data-from-organisaatio-palvelu
   [organisaatio]
-  (let [org-from-organisaatio-palvelu (organisaatio-client/get-by-oid-cached (:oid organisaatio))]
-    (assoc organisaatio :status (:status org-from-organisaatio-palvelu))))
+  (let [org-from-organisaatio-palvelu (organisaatio-client/get-by-oid-cached (:oid organisaatio))
+       yhteystiedot (parse-yhteystiedot org-from-organisaatio-palvelu ["fi", "sv", "en"])]
+    (-> organisaatio
+        (assoc :status (:status org-from-organisaatio-palvelu))
+        (assoc-in [:metadata :yhteystiedot] yhteystiedot))
+    ))
 
 (defn- oppilaitos-entry-with-osat
   [organisaatio]
   (let [oppilaitos-oid (:oid organisaatio)
         oppilaitos (or (kouta-backend/get-oppilaitos oppilaitos-oid) {})
+        oppilaitos-from-organisaatiopalvelu (organisaatio-client/get-by-oid-cached oppilaitos-oid)
+        oppilaitos-languages (distinct
+                               (for [yhteystieto (get-in oppilaitos-from-organisaatiopalvelu [:yhteystiedot])
+                                     :let [language (get-in yhteystieto [:kieli])]]
+                                 (let [[_ lang] (re-find #"_(.+)#" language)] lang)))
+        yhteystiedot (parse-yhteystiedot oppilaitos-from-organisaatiopalvelu oppilaitos-languages)
+        oppilaitos-metadata (assoc (get-in oppilaitos [:metadata]) :yhteystiedot yhteystiedot)
+        enriched-oppilaitos (assoc oppilaitos :metadata oppilaitos-metadata)
         oppilaitoksen-osat (map #(add-data-from-organisaatio-palvelu %) (kouta-backend/get-oppilaitoksen-osat oppilaitos-oid))
         koulutukset (kouta-backend/get-koulutukset-by-tarjoaja (:oid organisaatio))
-        find-oppilaitoksen-osa (fn [child] (or (first (filter #(= (:oid %) (:oid child)) oppilaitoksen-osat)) {}))]
-    (-> (oppilaitos-entry organisaatio oppilaitos koulutukset)
+        find-oppilaitoksen-osa (fn [child] (or (first (filter #(= (:oid %) (:oid child)) oppilaitoksen-osat)) {}))
+        ]
+    (-> (oppilaitos-entry organisaatio enriched-oppilaitos koulutukset)
         (assoc :osat (->> (organisaatio-tool/get-indexable-children organisaatio)
                           (map #(oppilaitoksen-osa-entry % (find-oppilaitoksen-osa %)))
                           (vec)))

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
@@ -57,20 +57,25 @@
       [(keyword lang) yhteystieto])))
 
 (defn create-kielistetty-osoitetieto
-  [osoitetieto languages]
+  [osoitetieto ulkomainen_osoite_en languages]
   (let [katuosoite (create-kielistetty-yhteystieto osoitetieto :osoite languages)
         postinumero_uri (create-kielistetty-yhteystieto osoitetieto :postinumeroUri languages)
         postinumero (zipmap
                       (keys postinumero_uri)
                       (map #(clojure.string/replace % #"posti_" "") (vals postinumero_uri)))
         postitoimipaikka (create-kielistetty-yhteystieto osoitetieto :postitoimipaikka languages)
-        capitalized_postitoimipaikka (zipmap (keys postitoimipaikka) (map #(clojure.string/capitalize %) (vals postitoimipaikka)))
+        capitalized_postitoimipaikka (zipmap
+                                       (keys postitoimipaikka)
+                                       (map #(clojure.string/capitalize %) (vals postitoimipaikka)))
         postinro_ja_toimipaikka (merge-with #(str %1 " " %2)
                                             postinumero
-                                            capitalized_postitoimipaikka)]
-    (merge-with #(str %1 ", " %2)
-                katuosoite
-                postinro_ja_toimipaikka)))
+                                            capitalized_postitoimipaikka)
+        kielistetyt_osoitteet (merge-with #(str %1 ", " %2)
+                                          katuosoite
+                                          postinro_ja_toimipaikka)]
+    (if (and (not (:en kielistetyt_osoitteet)) (not (empty? ulkomainen_osoite_en)))
+      (assoc kielistetyt_osoitteet :en (clojure.string/replace (:osoite (first ulkomainen_osoite_en)) #"\n" ", "))
+      kielistetyt_osoitteet)))
 
 (defn parse-yhteystiedot
   [response languages]
@@ -78,12 +83,20 @@
         sahkopostit (filter (fn [yhteystieto] (get-in yhteystieto [:email])) yhteystiedot)
         puhelinnumerot (filter (fn [yhteystieto] (= "puhelin" (get-in yhteystieto [:tyyppi]))) yhteystiedot)
         postiosoitteet (filter (fn [yhteystieto] (= "posti" (get-in yhteystieto [:osoiteTyyppi]))) yhteystiedot)
-        kayntiosoitteet (filter (fn [yhteystieto] (= "kaynti" (get-in yhteystieto [:osoiteTyyppi]))) yhteystiedot)]
-  [{:nimi (:nimi response)
-    :sahkoposti (create-kielistetty-yhteystieto sahkopostit :email languages)
-    :puhelinnumero (create-kielistetty-yhteystieto puhelinnumerot :numero languages)
-    :postiosoite (create-kielistetty-osoitetieto postiosoitteet languages)
-    :kayntiosoite (create-kielistetty-osoitetieto kayntiosoitteet languages)}]))
+        kayntiosoitteet (filter (fn [yhteystieto] (= "kaynti" (get-in yhteystieto [:osoiteTyyppi]))) yhteystiedot)
+        ulkomainen_posti_en (filter (fn [yhteystieto] (and
+                                                        (= "ulkomainen_posti" (get-in yhteystieto [:osoiteTyyppi]))
+                                                        (re-find #"kieli_en" (get-in yhteystieto [:kieli]))))
+                                    yhteystiedot)
+        ulkomainen_kaynti_en (filter (fn [yhteystieto] (and
+                                                        (= "ulkomainen_kaynti" (get-in yhteystieto [:osoiteTyyppi]))
+                                                        (re-find #"kieli_en" (get-in yhteystieto [:kieli]))))
+                                    yhteystiedot)]
+    [{:nimi (:nimi response)
+      :sahkoposti (create-kielistetty-yhteystieto sahkopostit :email languages)
+      :puhelinnumero (create-kielistetty-yhteystieto puhelinnumerot :numero languages)
+      :postiosoite (create-kielistetty-osoitetieto postiosoitteet ulkomainen_posti_en languages)
+      :kayntiosoite (create-kielistetty-osoitetieto kayntiosoitteet ulkomainen_kaynti_en languages)}]))
 
 (defn- add-data-from-organisaatio-palvelu
   [organisaatio]

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
@@ -10,6 +10,7 @@
             [kouta-indeksoija-service.indexer.indexable :as indexable]))
 
 (def index-name "oppilaitos-kouta")
+(def languages ["fi" "en" "sv"])
 
 (defn- organisaatio-entry
   [organisaatio]
@@ -74,7 +75,7 @@
 (defn- add-data-from-organisaatio-palvelu
   [organisaatio]
   (let [org-from-organisaatio-palvelu (organisaatio-client/get-by-oid-cached (:oid organisaatio))
-       yhteystiedot (parse-yhteystiedot org-from-organisaatio-palvelu ["fi", "sv", "en"])]
+       yhteystiedot (parse-yhteystiedot org-from-organisaatio-palvelu languages)]
     (-> organisaatio
         (assoc :status (:status org-from-organisaatio-palvelu))
         (assoc-in [:metadata :yhteystiedot] yhteystiedot))
@@ -85,11 +86,7 @@
   (let [oppilaitos-oid (:oid organisaatio)
         oppilaitos (or (kouta-backend/get-oppilaitos oppilaitos-oid) {})
         oppilaitos-from-organisaatiopalvelu (organisaatio-client/get-by-oid-cached oppilaitos-oid)
-        oppilaitos-languages (distinct
-                               (for [yhteystieto (get-in oppilaitos-from-organisaatiopalvelu [:yhteystiedot])
-                                     :let [language (get-in yhteystieto [:kieli])]]
-                                 (let [[_ lang] (re-find #"_(.+)#" language)] lang)))
-        yhteystiedot (parse-yhteystiedot oppilaitos-from-organisaatiopalvelu oppilaitos-languages)
+        yhteystiedot (parse-yhteystiedot oppilaitos-from-organisaatiopalvelu languages)
         oppilaitos-metadata (assoc (get-in oppilaitos [:metadata]) :yhteystiedot yhteystiedot)
         enriched-oppilaitos (assoc oppilaitos :metadata oppilaitos-metadata)
         oppilaitoksen-osat (map #(add-data-from-organisaatio-palvelu %) (kouta-backend/get-oppilaitoksen-osat oppilaitos-oid))

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
@@ -57,6 +57,11 @@
       [(keyword lang) yhteystieto])))
 
 (defn create-kielistetty-osoitetieto
+  [osoitetieto languages]
+  {:osoite (create-kielistetty-yhteystieto osoitetieto :osoite languages)
+   :postinumeroKoodiUri (:postinumeroUri (first (filter (fn [os] (get-in os [:postinumeroUri])) osoitetieto)))})
+
+(defn create-kielistetty-osoite-str
   [osoitetieto ulkomainen_osoite_en languages]
   (let [katuosoite (create-kielistetty-yhteystieto osoitetieto :osoite languages)
         postinumero_uri (create-kielistetty-yhteystieto osoitetieto :postinumeroUri languages)
@@ -95,8 +100,10 @@
     [{:nimi (:nimi response)
       :sahkoposti (create-kielistetty-yhteystieto sahkopostit :email languages)
       :puhelinnumero (create-kielistetty-yhteystieto puhelinnumerot :numero languages)
-      :postiosoite (create-kielistetty-osoitetieto postiosoitteet ulkomainen_posti_en languages)
-      :kayntiosoite (create-kielistetty-osoitetieto kayntiosoitteet ulkomainen_kaynti_en languages)}]))
+      :postiosoite (create-kielistetty-osoitetieto postiosoitteet languages)
+      :kayntiosoite (create-kielistetty-osoitetieto kayntiosoitteet languages)
+      :postiosoiteStr (create-kielistetty-osoite-str postiosoitteet ulkomainen_posti_en languages)
+      :kayntiosoiteStr (create-kielistetty-osoite-str kayntiosoitteet ulkomainen_kaynti_en languages)}]))
 
 (defn- add-data-from-organisaatio-palvelu
   [organisaatio]

--- a/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/oppilaitos.clj
@@ -58,8 +58,19 @@
 
 (defn create-kielistetty-osoitetieto
   [osoitetieto languages]
-  {:osoite (create-kielistetty-yhteystieto osoitetieto :osoite languages)
-   :postinumeroKoodiUri (:postinumeroUri (first (filter (fn [os] (get-in os [:postinumeroUri])) osoitetieto)))})
+  (let [katuosoite (create-kielistetty-yhteystieto osoitetieto :osoite languages)
+        postinumero_uri (create-kielistetty-yhteystieto osoitetieto :postinumeroUri languages)
+        postinumero (zipmap
+                      (keys postinumero_uri)
+                      (map #(clojure.string/replace % #"posti_" "") (vals postinumero_uri)))
+        postitoimipaikka (create-kielistetty-yhteystieto osoitetieto :postitoimipaikka languages)
+        capitalized_postitoimipaikka (zipmap (keys postitoimipaikka) (map #(clojure.string/capitalize %) (vals postitoimipaikka)))
+        postinro_ja_toimipaikka (merge-with #(str %1 " " %2)
+                                            postinumero
+                                            capitalized_postitoimipaikka)]
+    (merge-with #(str %1 ", " %2)
+                katuosoite
+                postinro_ja_toimipaikka)))
 
 (defn parse-yhteystiedot
   [response languages]

--- a/test/kouta_indeksoija_service/indexer/kouta_indexer_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_indexer_test.clj
@@ -31,8 +31,6 @@
 
 (defn mock-organisaatio
   [oid & {:as params}]
-  (println "mock-organisaatio")
-  (println oid)
   (parse (str "test/resources/organisaatiot/1.2.246.562.10.10101010101-v4.json")))
 
 (defn mock-organisaatio-hierarkia-v4

--- a/test/kouta_indeksoija_service/indexer/kouta_indexer_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_indexer_test.clj
@@ -29,6 +29,12 @@
   [oid & {:as params}]
   (parse (str "test/resources/organisaatiot/1.2.246.562.10.10101010101-hierarkia.json")))
 
+(defn mock-organisaatio
+  [oid & {:as params}]
+  (println "mock-organisaatio")
+  (println oid)
+  (parse (str "test/resources/organisaatiot/1.2.246.562.10.10101010101-v4.json")))
+
 (defn mock-organisaatio-hierarkia-v4
   [oid]
   (kouta-indeksoija-service.fixture.kouta-indexer-fixture/mock-organisaatio-hierarkia-v4 oid))
@@ -87,7 +93,7 @@
 (deftest index-oppilaitos-test
   (fixture/with-mocked-indexing
    (with-redefs [kouta-indeksoija-service.rest.organisaatio/get-hierarkia-for-oid-from-cache mock-organisaatio-hierarkia
-                 kouta-indeksoija-service.rest.organisaatio/get-by-oid-cached kouta-indeksoija-service.fixture.external-services/mock-organisaatio]
+                 kouta-indeksoija-service.rest.organisaatio/get-by-oid-cached mock-organisaatio]
      (testing "Indexer should index oppilaitos and it's osat to oppilaitos index"
        (check-all-nil)
        (add-toteutus-for-oppilaitos)
@@ -98,7 +104,7 @@
 (deftest index-oppilaitos-test-2
  (fixture/with-mocked-indexing
   (with-redefs [kouta-indeksoija-service.rest.organisaatio/get-hierarkia-for-oid-from-cache mock-organisaatio-hierarkia
-                kouta-indeksoija-service.rest.organisaatio/get-by-oid-cached kouta-indeksoija-service.fixture.external-services/mock-organisaatio]
+                kouta-indeksoija-service.rest.organisaatio/get-by-oid-cached mock-organisaatio]
     (testing "Indexer should index oppilaitos and it's osat to oppilaitos index when given oppilaitoksen osa oid"
       (check-all-nil)
       (add-toteutus-for-oppilaitos)

--- a/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
@@ -81,7 +81,7 @@
              (oppilaitos/create-kielistetty-yhteystieto sahkoposti :email languages))))))
 
 (deftest create-kielistetty-osoitetieto
-  (testing "returns kielistetty osoitetieto with (katu)osoite and postinumero that has fields for name and koodiUri"
+  (testing "returns kielistetty osoitetieto that has fields for postinumeroKoodiUri and (katu)osoite"
     (let [postiosoite [{:osoiteTyyppi "posti"
                         :kieli "kieli_fi#1"
                         :postinumeroUri "posti_00076"
@@ -123,7 +123,7 @@
       (is (= {:fi "Nakertajanraitti 1" :sv "PB 11110, 00076 Aalto"}
              (oppilaitos/create-kielistetty-osoite-str postiosoite [] languages)))))
 
-  (testing "uses ulkomainen_posti as the value for english osoite because it is missing from posti osoiteTyyppi"
+  (testing "uses ulkomainen_posti as the value for english osoite because it doesn't exist in objects that have posti as osoiteTyyppi"
     (let [postiosoite [{:osoiteTyyppi "posti"
                         :kieli "kieli_fi#1"
                         :postinumeroUri "posti_00076"
@@ -166,6 +166,3 @@
   (testing "returns kayntiosoite_str map with addresses for all languages"
     (is (= {:fi "Otakaari 1, 02150 Espoo" :sv "Otsvängen 1, 02150 Esbo" :en "12 Example Street, Northolt, London, UB5 4AS, UK"}
            (:kayntiosoiteStr (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0))))))
-
-(require '[clojure.test :refer [run-tests]])
-(run-tests)

--- a/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
@@ -1,0 +1,119 @@
+(ns kouta-indeksoija-service.indexer.kouta-oppilaitos-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [kouta-indeksoija-service.indexer.kouta.oppilaitos :as oppilaitos]))
+
+(def oppilaitos-response
+  {:nimi
+   {:fi "Aalto-yliopisto"
+    :sv "Aalto-universitetet"
+    :en "Aalto University"}
+   :yhteystiedot
+   [{:osoiteTyyppi "kaynti"
+     :kieli "kieli_fi#1"
+     :postinumeroUri "posti_02150"
+     :postitoimipaikka "ESPOO"
+     :osoite "Otakaari 1"}
+    {:osoiteTyyppi "posti"
+     :kieli "kieli_fi#1"
+     :postinumeroUri "posti_00076"
+     :postitoimipaikka "AALTO"
+     :osoite "PL 11110"}
+    {:kieli "kieli_fi#1"
+     :email "hakijapalvelut@aalto.fi"}
+    {:kieli "kieli_fi#1"
+     :www "http://www.aalto.fi/studies"}
+    {:kieli "kieli_fi#1"
+     :numero "0294429290"
+     :tyyppi "puhelin"}
+    {:osoiteTyyppi "kaynti"
+     :kieli "kieli_sv#1"
+     :postinumeroUri "posti_02150"
+     :postitoimipaikka "ESBO"
+     :osoite "Otsvängen 1"}
+    {:osoiteTyyppi "posti"
+     :kieli "kieli_sv#1"
+     :postinumeroUri "posti_00076"
+     :postitoimipaikka "AALTO"
+     :osoite "PB 11110"}
+    {:kieli "kieli_sv#1"
+     :email "ansokningsservice@aalto.fi"}
+    {:kieli "kieli_sv#1"
+     :www "http://www.aalto.fi/sv/studies"}
+    {:kieli "kieli_sv#1"
+     :numero "0294429290"
+     :tyyppi "puhelin"}
+    {:kieli "kieli_en#1"
+     :email "admissions@aalto.fi"}
+    {:kieli "kieli_en#1"
+     :www "http://www.aalto.fi/en/studies"}
+    {:kieli "kieli_en#1"
+     :numero "+358294429290"
+     :tyyppi "puhelin"}]})
+
+(def languages ["fi", "sv", "en"])
+
+(deftest create-kielistetty-yhteystieto
+  (testing "returns empty map if empty list given as a parameter"
+    (is (= {}
+           (oppilaitos/create-kielistetty-yhteystieto {} :email languages))))
+
+  (testing "returns kielistetty sahkoposti with english as the only language"
+    (let [sahkoposti [{:kieli "kieli_en#1" :email "admissions@aalto.fi"}]]
+      (is (= {:en "admissions@aalto.fi"}
+             (oppilaitos/create-kielistetty-yhteystieto sahkoposti :email languages)))))
+  )
+
+(deftest create-kielistetty-osoitetieto
+  (testing "returns kielistetty osoitetieto with (katu)osoite and postinumero that has fields for name and koodiUri"
+    (let [postiosoite [{:osoiteTyyppi "posti"
+                        :kieli "kieli_fi#1"
+                        :postinumeroUri "posti_00076"
+                        :postitoimipaikka "AALTO"
+                        :osoite "PL 11110"}
+                       {:osoiteTyyppi "posti"
+                        :kieli "kieli_sv#1"
+                        :postinumeroUri "posti_00076"
+                        :postitoimipaikka "AALTO"
+                        :osoite "PB 11110"}]]
+      (is (= {:osoite {:fi "PL 11110" :sv "PB 11110"}
+              :postinumeroKoodiUri "posti_00076"}
+             (oppilaitos/create-kielistetty-osoitetieto postiosoite languages)))))
+  )
+
+(deftest parse-yhteystiedot
+  (testing "returns kielistetty nimi as it is in organisaatiopalveluresponse"
+    (is (= {:fi "Aalto-yliopisto"
+            :sv "Aalto-universitetet"
+            :en "Aalto University"}
+           (:nimi (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
+
+  (testing "returns sahkoposti map with fi, en and sv language emails"
+    (is (= {:fi "hakijapalvelut@aalto.fi"
+            :en "admissions@aalto.fi"
+            :sv "ansokningsservice@aalto.fi"}
+           (:sahkoposti (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
+
+  (testing "returns puhelinnumero map with fi, sv and en language phone numbers"
+    (is (= {:fi "0294429290"
+            :sv "0294429290"
+            :en "+358294429290"}
+           (:puhelinnumero (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
+
+  (testing "returns postiosoite map with osoite and postinumero fields for all languages"
+    (is (= {:osoite {:fi "PL 11110" :sv "PB 11110"}
+            :postinumeroKoodiUri "posti_00076"}
+           (:postiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
+
+  (testing "returns postiosoite map with osoite and postinumero fields for all languages"
+    (is (= {:osoite {:fi "PL 11110" :sv "PB 11110"}
+            :postinumeroKoodiUri "posti_00076"}
+           (:postiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
+
+  (testing "returns kayntiosoite map with osoite and postinumero fields for all languages"
+    (is (= {:osoite {:fi "Otakaari 1" :sv "Otsvängen 1"}
+            :postinumeroKoodiUri "posti_02150"}
+           (:kayntiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
+  )
+
+(require '[clojure.test :refer [run-tests]])
+(run-tests)

--- a/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
@@ -166,3 +166,12 @@
   (testing "returns kayntiosoite_str map with addresses for all languages"
     (is (= {:fi "Otakaari 1, 02150 Espoo" :sv "Otsvängen 1, 02150 Esbo" :en "12 Example Street, Northolt, London, UB5 4AS, UK"}
            (:kayntiosoiteStr (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0))))))
+
+(deftest create-osoite-str-for-hakijapalvelut
+  (testing "creates osoite string for fi and en languages"
+    (is (= {:en "PO BOX 4000, 00076 Espoo" :fi "PL 4000, 00076 Espoo" }
+           (oppilaitos/create-osoite-str-for-hakijapalvelut {:en "PO BOX 4000" :fi "PL 4000"} "00076" {:fi "ESPOO" :sv "ESBO" :en "ESPOO"}))))
+
+  (testing "sets finnish language postitoimipaikka as the default"
+    (is (= {:en "PO BOX 4000, 00076 Espoo" :fi "PL 4000, 00076 Espoo" }
+           (oppilaitos/create-osoite-str-for-hakijapalvelut {:en "PO BOX 4000" :fi "PL 4000"} "00076" {:fi "ESPOO" :sv "ESBO"})))) )

--- a/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
@@ -30,6 +30,9 @@
      :postinumeroUri "posti_02150"
      :postitoimipaikka "ESBO"
      :osoite "Otsvängen 1"}
+    {:osoiteTyyppi "ulkomainen_kaynti"
+     :kieli "kieli_en#1"
+     :osoite "12 Example Street\nNortholt\nLondon\nUB5 4AS\nUK"}
     {:osoiteTyyppi "posti"
      :kieli "kieli_sv#1"
      :postinumeroUri "posti_00076"
@@ -44,6 +47,12 @@
      :tyyppi "puhelin"}
     {:kieli "kieli_en#1"
      :email "admissions@aalto.fi"}
+    {:osoiteTyyppi "ulkomainen_posti"
+     :kieli "kieli_de#1"
+     :osoite "Mozartstr. 9\n12349 Berlin\nGERMANY"}
+    {:osoiteTyyppi "ulkomainen_posti"
+     :kieli "kieli_en#1"
+     :osoite "1 Example Street\nNortholt\nLondon\nUB5 4AS\nUK"}
     {:kieli "kieli_en#1"
      :www "http://www.aalto.fi/en/studies"}
     {:kieli "kieli_en#1"
@@ -72,7 +81,7 @@
              (oppilaitos/create-kielistetty-yhteystieto sahkoposti :email languages))))))
 
 (deftest create-kielistetty-osoitetieto
-  (testing "returns kielistetty osoitetieto with (katu)osoite and postinumero that has fields for name and koodiUri"
+  (testing "returns kielistetty osoite string with katuosoite, postinumero and postitoimipaikka"
     (let [postiosoite [{:osoiteTyyppi "posti"
                         :kieli "kieli_fi#1"
                         :postinumeroUri "posti_00076"
@@ -84,9 +93,9 @@
                         :postitoimipaikka "AALTO"
                         :osoite "PB 11110"}]]
       (is (= {:fi "PL 11110, 00076 Aalto" :sv "PB 11110, 00076 Aalto"}
-             (oppilaitos/create-kielistetty-osoitetieto postiosoite languages)))))
+             (oppilaitos/create-kielistetty-osoitetieto postiosoite [] languages)))))
 
-  (testing "returns kielistetty osoitetieto with (katu)osoite and postinumero that has fields for name and koodiUri"
+  (testing "returns kielistetty osoite string that doesn't have postinumero and -toimipaikka for finnish language"
     (let [postiosoite [{:osoiteTyyppi "posti"
                         :kieli "kieli_fi#1"
                         :osoite "Nakertajanraitti 1"}
@@ -96,7 +105,19 @@
                         :postitoimipaikka "AALTO"
                         :osoite "PB 11110"}]]
       (is (= {:fi "Nakertajanraitti 1" :sv "PB 11110, 00076 Aalto"}
-             (oppilaitos/create-kielistetty-osoitetieto postiosoite languages))))))
+             (oppilaitos/create-kielistetty-osoitetieto postiosoite [] languages)))))
+
+  (testing "uses ulkomainen_posti as the value for english osoite because it is missing from posti osoiteTyyppi"
+    (let [postiosoite [{:osoiteTyyppi "posti"
+                        :kieli "kieli_fi#1"
+                        :postinumeroUri "posti_00076"
+                        :postitoimipaikka "AALTO"
+                        :osoite "PL 11110"}]
+          ulkomainen_posti [{:osoiteTyyppi "ulkomainen_posti"
+                                   :kieli "kieli_en#1"
+                                   :osoite "1 Example Street\nNortholt\nLondon\nUB5 4AS\nUK"}]]
+      (is (= {:fi "PL 11110, 00076 Aalto" :en "1 Example Street, Northolt, London, UB5 4AS, UK"}
+             (oppilaitos/create-kielistetty-osoitetieto postiosoite ulkomainen_posti languages))))))
 
 (deftest parse-yhteystiedot
   (testing "returns kielistetty nimi as it is in organisaatiopalveluresponse"
@@ -118,11 +139,11 @@
            (:puhelinnumero (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
 
   (testing "returns postiosoite map with osoite and postinumero fields for all languages"
-    (is (= {:fi "PL 11110, 00076 Aalto" :sv "PB 11110, 00076 Aalto"}
+    (is (= {:fi "PL 11110, 00076 Aalto" :sv "PB 11110, 00076 Aalto" :en "1 Example Street, Northolt, London, UB5 4AS, UK"}
            (:postiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
 
   (testing "returns kayntiosoite map with osoite and postinumero fields for all languages"
-    (is (= {:fi "Otakaari 1, 02150 Espoo" :sv "Otsvängen 1, 02150 Esbo"}
+    (is (= {:fi "Otakaari 1, 02150 Espoo" :sv "Otsvängen 1, 02150 Esbo" :en "12 Example Street, Northolt, London, UB5 4AS, UK"}
            (:kayntiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0))))))
 
 (require '[clojure.test :refer [run-tests]])

--- a/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
@@ -81,6 +81,22 @@
              (oppilaitos/create-kielistetty-yhteystieto sahkoposti :email languages))))))
 
 (deftest create-kielistetty-osoitetieto
+  (testing "returns kielistetty osoitetieto with (katu)osoite and postinumero that has fields for name and koodiUri"
+    (let [postiosoite [{:osoiteTyyppi "posti"
+                        :kieli "kieli_fi#1"
+                        :postinumeroUri "posti_00076"
+                        :postitoimipaikka "AALTO"
+                        :osoite "PL 11110"}
+                       {:osoiteTyyppi "posti"
+                        :kieli "kieli_sv#1"
+                        :postinumeroUri "posti_00076"
+                        :postitoimipaikka "AALTO"
+                        :osoite "PB 11110"}]]
+      (is (= {:osoite {:fi "PL 11110" :sv "PB 11110"}
+              :postinumeroKoodiUri "posti_00076"}
+             (oppilaitos/create-kielistetty-osoitetieto postiosoite languages))))))
+
+(deftest create-kielistetty-osoite-str
   (testing "returns kielistetty osoite string with katuosoite, postinumero and postitoimipaikka"
     (let [postiosoite [{:osoiteTyyppi "posti"
                         :kieli "kieli_fi#1"
@@ -93,7 +109,7 @@
                         :postitoimipaikka "AALTO"
                         :osoite "PB 11110"}]]
       (is (= {:fi "PL 11110, 00076 Aalto" :sv "PB 11110, 00076 Aalto"}
-             (oppilaitos/create-kielistetty-osoitetieto postiosoite [] languages)))))
+             (oppilaitos/create-kielistetty-osoite-str postiosoite [] languages)))))
 
   (testing "returns kielistetty osoite string that doesn't have postinumero and -toimipaikka for finnish language"
     (let [postiosoite [{:osoiteTyyppi "posti"
@@ -105,7 +121,7 @@
                         :postitoimipaikka "AALTO"
                         :osoite "PB 11110"}]]
       (is (= {:fi "Nakertajanraitti 1" :sv "PB 11110, 00076 Aalto"}
-             (oppilaitos/create-kielistetty-osoitetieto postiosoite [] languages)))))
+             (oppilaitos/create-kielistetty-osoite-str postiosoite [] languages)))))
 
   (testing "uses ulkomainen_posti as the value for english osoite because it is missing from posti osoiteTyyppi"
     (let [postiosoite [{:osoiteTyyppi "posti"
@@ -117,7 +133,7 @@
                                    :kieli "kieli_en#1"
                                    :osoite "1 Example Street\nNortholt\nLondon\nUB5 4AS\nUK"}]]
       (is (= {:fi "PL 11110, 00076 Aalto" :en "1 Example Street, Northolt, London, UB5 4AS, UK"}
-             (oppilaitos/create-kielistetty-osoitetieto postiosoite ulkomainen_posti languages))))))
+             (oppilaitos/create-kielistetty-osoite-str postiosoite ulkomainen_posti languages))))))
 
 (deftest parse-yhteystiedot
   (testing "returns kielistetty nimi as it is in organisaatiopalveluresponse"
@@ -138,13 +154,18 @@
             :en "+358294429290"}
            (:puhelinnumero (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
 
-  (testing "returns postiosoite map with osoite and postinumero fields for all languages"
+  (testing "returns postiosoite_str map with addresses for all languages"
     (is (= {:fi "PL 11110, 00076 Aalto" :sv "PB 11110, 00076 Aalto" :en "1 Example Street, Northolt, London, UB5 4AS, UK"}
+           (:postiosoiteStr (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
+
+  (testing "returns postiosoite with kielistetty osoite and postinumeroKoodiUri"
+    (is (= {:osoite {:fi "PL 11110" :sv "PB 11110"}
+            :postinumeroKoodiUri "posti_00076"}
            (:postiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
 
-  (testing "returns kayntiosoite map with osoite and postinumero fields for all languages"
+  (testing "returns kayntiosoite_str map with addresses for all languages"
     (is (= {:fi "Otakaari 1, 02150 Espoo" :sv "Otsvängen 1, 02150 Esbo" :en "12 Example Street, Northolt, London, UB5 4AS, UK"}
-           (:kayntiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0))))))
+           (:kayntiosoiteStr (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0))))))
 
 (require '[clojure.test :refer [run-tests]])
 (run-tests)

--- a/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
@@ -35,7 +35,7 @@
      :osoite "12 Example Street\nNortholt\nLondon\nUB5 4AS\nUK"}
     {:osoiteTyyppi "posti"
      :kieli "kieli_sv#1"
-     :postinumeroUri "posti_00076"
+     :postinumeroUri "posti_00076#2"
      :postitoimipaikka "AALTO"
      :osoite "PB 11110"}
     {:kieli "kieli_sv#1"

--- a/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
@@ -61,6 +61,15 @@
     (let [sahkoposti [{:kieli "kieli_en#1" :email "admissions@aalto.fi"}]]
       (is (= {:en "admissions@aalto.fi"}
              (oppilaitos/create-kielistetty-yhteystieto sahkoposti :email languages)))))
+
+  (testing "returns kielistetty sahkoposti with all languages"
+    (let [sahkoposti [{:kieli "kieli_en#1" :email "admissions@aalto.fi"}
+                      {:kieli "kieli_fi#1" :email "hakijapalvelut@aalto.fi"}
+                      {:kieli "kieli_sv#1" :email "ansokningsservice@aalto.fi"}]]
+      (is (= {:en "admissions@aalto.fi"
+              :fi "hakijapalvelut@aalto.fi"
+              :sv "ansokningsservice@aalto.fi"}
+             (oppilaitos/create-kielistetty-yhteystieto sahkoposti :email languages)))))
   )
 
 (deftest create-kielistetty-osoitetieto

--- a/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_oppilaitos_test.clj
@@ -69,8 +69,7 @@
       (is (= {:en "admissions@aalto.fi"
               :fi "hakijapalvelut@aalto.fi"
               :sv "ansokningsservice@aalto.fi"}
-             (oppilaitos/create-kielistetty-yhteystieto sahkoposti :email languages)))))
-  )
+             (oppilaitos/create-kielistetty-yhteystieto sahkoposti :email languages))))))
 
 (deftest create-kielistetty-osoitetieto
   (testing "returns kielistetty osoitetieto with (katu)osoite and postinumero that has fields for name and koodiUri"
@@ -84,10 +83,20 @@
                         :postinumeroUri "posti_00076"
                         :postitoimipaikka "AALTO"
                         :osoite "PB 11110"}]]
-      (is (= {:osoite {:fi "PL 11110" :sv "PB 11110"}
-              :postinumeroKoodiUri "posti_00076"}
+      (is (= {:fi "PL 11110, 00076 Aalto" :sv "PB 11110, 00076 Aalto"}
              (oppilaitos/create-kielistetty-osoitetieto postiosoite languages)))))
-  )
+
+  (testing "returns kielistetty osoitetieto with (katu)osoite and postinumero that has fields for name and koodiUri"
+    (let [postiosoite [{:osoiteTyyppi "posti"
+                        :kieli "kieli_fi#1"
+                        :osoite "Nakertajanraitti 1"}
+                       {:osoiteTyyppi "posti"
+                        :kieli "kieli_sv#1"
+                        :postinumeroUri "posti_00076"
+                        :postitoimipaikka "AALTO"
+                        :osoite "PB 11110"}]]
+      (is (= {:fi "Nakertajanraitti 1" :sv "PB 11110, 00076 Aalto"}
+             (oppilaitos/create-kielistetty-osoitetieto postiosoite languages))))))
 
 (deftest parse-yhteystiedot
   (testing "returns kielistetty nimi as it is in organisaatiopalveluresponse"
@@ -109,20 +118,12 @@
            (:puhelinnumero (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
 
   (testing "returns postiosoite map with osoite and postinumero fields for all languages"
-    (is (= {:osoite {:fi "PL 11110" :sv "PB 11110"}
-            :postinumeroKoodiUri "posti_00076"}
-           (:postiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
-
-  (testing "returns postiosoite map with osoite and postinumero fields for all languages"
-    (is (= {:osoite {:fi "PL 11110" :sv "PB 11110"}
-            :postinumeroKoodiUri "posti_00076"}
+    (is (= {:fi "PL 11110, 00076 Aalto" :sv "PB 11110, 00076 Aalto"}
            (:postiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
 
   (testing "returns kayntiosoite map with osoite and postinumero fields for all languages"
-    (is (= {:osoite {:fi "Otakaari 1" :sv "Otsvängen 1"}
-            :postinumeroKoodiUri "posti_02150"}
-           (:kayntiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0)))))
-  )
+    (is (= {:fi "Otakaari 1, 02150 Espoo" :sv "Otsvängen 1, 02150 Esbo"}
+           (:kayntiosoite (nth (oppilaitos/parse-yhteystiedot oppilaitos-response languages) 0))))))
 
 (require '[clojure.test :refer [run-tests]])
 (run-tests)

--- a/test/resources/kouta/kouta-oppilaitos-result.json
+++ b/test/resources/kouta/kouta-oppilaitos-result.json
@@ -91,6 +91,19 @@
                   }
                 }
               },
+              "kayntiosoite": {
+                "osoite": {
+                  "fi": "Kivatie 1",
+                  "sv": "kivavägen 1"
+                },
+                "postinumero": {
+                  "koodiUri": "posti_04230#2",
+                  "nimi": {
+                    "fi": "posti_04230#2 nimi fi",
+                    "sv": "posti_04230#2 nimi sv"
+                  }
+                }
+              },
               "puhelinnumero": {
                 "fi": "123",
                 "sv": "123"

--- a/test/resources/kouta/kouta-oppilaitos-result.json
+++ b/test/resources/kouta/kouta-oppilaitos-result.json
@@ -305,6 +305,10 @@
             }
           }
         },
+        "postiosoiteStr": {
+          "fi": "Kivatie 1, 04230 Posti_04230#2 nimi fi",
+          "sv": "kivavägen 1, 04230 Posti_04230#2 nimi sv"
+        },
         "puhelinnumero": {
           "fi": "123",
           "sv": "123"

--- a/test/resources/kouta/kouta-oppilaitos-result.json
+++ b/test/resources/kouta/kouta-oppilaitos-result.json
@@ -91,6 +91,11 @@
                   }
                 }
               },
+              "postiosoiteStr": {
+                "fi": "Kivatie 1, 04230 Espoo",
+                "sv": "kivavägen 1, 04230 Aalto",
+                "en": "Katumatie 805"
+              },
               "kayntiosoite": {
                 "osoite": {
                   "fi": "Kivatie 1",
@@ -103,6 +108,11 @@
                     "sv": "posti_04230#2 nimi sv"
                   }
                 }
+              },
+              "kayntiosoiteStr": {
+                "fi": "Kivatie 1, 04230 Espoo",
+                "sv": "kivavägen 1, 04230 Esbo",
+                "en": "Jalanluiskahtamavaarankuja 610"
               },
               "puhelinnumero": {
                 "fi": "123",
@@ -244,6 +254,11 @@
               }
             }
           },
+          "postiosoiteStr": {
+            "fi": "Kivatie 1, 04230 Espoo",
+            "sv": "kivavägen 1, 04230 Aalto",
+            "en": "Katumatie 805"
+          },
           "kayntiosoite": {
             "osoite": {
               "fi": "Kivatie 1",
@@ -256,6 +271,11 @@
                 "sv": "posti_04230#2 nimi sv"
               }
             }
+          },
+          "kayntiosoiteStr": {
+            "fi": "Kivatie 1, 04230 Espoo",
+            "sv": "kivavägen 1, 04230 Esbo",
+            "en": "Jalanluiskahtamavaarankuja 610"
           },
           "puhelinnumero": {
             "fi": "123",

--- a/test/resources/organisaatiot/1.2.246.562.10.10101010101-v4.json
+++ b/test/resources/organisaatiot/1.2.246.562.10.10101010101-v4.json
@@ -1,0 +1,105 @@
+{
+  "status": "AKTIIVINEN",
+  "oid": "1.2.246.562.10.10101010101",
+  "nimi": {
+    "fi": "nimi",
+    "sv": "nimi sv"
+  },
+  "yhteystiedot": [
+    {
+      "osoiteTyyppi": "ulkomainen_posti",
+      "kieli": "kieli_en#1",
+      "yhteystietoOid": "1.2.246.562.5.2014041712441998349381",
+      "id": "2195084",
+      "osoite": "Katumatie 805"
+    },
+    {
+      "osoiteTyyppi": "kaynti",
+      "kieli": "kieli_fi#1",
+      "postinumeroUri": "posti_04230#2",
+      "yhteystietoOid": "1.2.246.562.5.71229398194",
+      "id": "2195092",
+      "postitoimipaikka": "ESPOO",
+      "osoite": "Kivatie 1"
+    },
+    {
+      "osoiteTyyppi": "posti",
+      "kieli": "kieli_sv#1",
+      "postinumeroUri": "posti_04230#2",
+      "yhteystietoOid": "1.2.246.562.5.2014041712441998347411",
+      "id": "2195089",
+      "postitoimipaikka": "AALTO",
+      "osoite": "kivavägen 1"
+    },
+    {
+      "kieli": "kieli_fi#1",
+      "numero": "123",
+      "tyyppi": "puhelin",
+      "yhteystietoOid": "1.2.246.562.5.148410407610",
+      "id": "2195095"
+    },
+    {
+      "kieli": "kieli_sv#1",
+      "numero": "123",
+      "tyyppi": "puhelin",
+      "yhteystietoOid": "1.2.246.562.5.2014041712441998347868",
+      "id": "2195086"
+    },
+    {
+      "kieli": "kieli_sv#1",
+      "www": "http://www.aalto.fi/sv",
+      "yhteystietoOid": "13977278599820.439613666427096",
+      "id": "2195087"
+    },
+    {
+      "kieli": "kieli_fi#1",
+      "www": "http://www.aalto.fi/",
+      "yhteystietoOid": "1.2.246.562.5.91862370631",
+      "id": "2195094"
+    },
+    {
+      "kieli": "kieli_sv#1",
+      "yhteystietoOid": "13977278599820.24009499744648388",
+      "id": "2195088",
+      "email": "aku.ankka@ankkalinnankoulu.fi"
+    },
+    {
+      "osoiteTyyppi": "kaynti",
+      "kieli": "kieli_sv#1",
+      "postinumeroUri": "posti_04230#2",
+      "yhteystietoOid": "1.2.246.562.5.2014041712441998389679",
+      "id": "2195090",
+      "postitoimipaikka": "ESBO",
+      "osoite": "kivavägen 1"
+    },
+    {
+      "kieli": "kieli_en#1",
+      "www": "http://www.aalto.fi/en",
+      "yhteystietoOid": "13977278599820.3504394563753592",
+      "id": "2195082"
+    },
+    {
+      "osoiteTyyppi": "posti",
+      "kieli": "kieli_fi#1",
+      "postinumeroUri": "posti_04230#2",
+      "yhteystietoOid": "1.2.246.562.5.11101255088",
+      "id": "2195093",
+      "postitoimipaikka": "ESPOO",
+      "osoite": "Kivatie 1"
+    },
+    {
+      "osoiteTyyppi": "ulkomainen_kaynti",
+      "kieli": "kieli_en#1",
+      "yhteystietoOid": "1.2.246.562.5.2014041712441998318112",
+      "id": "2195085",
+      "osoite": "Jalanluiskahtamavaarankuja 610"
+    },
+    {
+      "kieli": "kieli_fi#1",
+      "yhteystietoOid": "1.2.246.562.5.2014032410460572795030",
+      "id": "2195091",
+      "email": "aku.ankka@ankkalinnankoulu.fi"
+    }
+  ],
+  "kotipaikkaUri": "kunta_091"
+}


### PR DESCRIPTION
Muutin toteutusta niin, että osoitteesta indeksoidaan myös esitysmuotoinen string konfo-ui:ta varten, koska enkunkielinen osoite ei välttämättä ole muotoa katuosoite +  postinumero enkä halunnut alkaa UI:n puolella puljaamaan noitten kieliversioitten välillä.