### PR TITLE
OY-3999 Use unprocessed hakukohde to deduce alkamiskausi

### DIFF
--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -239,8 +239,8 @@
              {:alkamiskausityyppi tyyppi
               :source             oid}))))
 
-(defn- assoc-paatelty-alkamiskausi-for-hakukohde [hakukohde haku toteutus]
-  (if-let [result (or (parse-alkamiskausi (get-in hakukohde [:metadata :koulutuksenAlkamiskausi]) (:oid hakukohde))
+(defn- assoc-paatelty-alkamiskausi-for-hakukohde [hakukohde hakukoude-source haku toteutus]
+  (if-let [result (or (parse-alkamiskausi (get-in hakukoude-source [:metadata :koulutuksenAlkamiskausi]) (:oid hakukohde))
                       (parse-alkamiskausi (get-in haku [:metadata :koulutuksenAlkamiskausi]) (:oid haku))
                       (parse-alkamiskausi (get-in toteutus [:metadata :opetus :koulutuksenAlkamiskausi]) (:oid toteutus)))]
     (assoc hakukohde :paateltyAlkamiskausi result)
@@ -402,7 +402,7 @@
                                                          (assoc-valintaperuste valintaperuste)
                                                          (assoc-jarjestaako-urheilijan-amm-koulutusta jarjestyspaikkaOid jarjestyspaikka-oppilaitos)
                                                          (assoc-hakulomake-linkki haku)
-                                                         (assoc-paatelty-alkamiskausi-for-hakukohde haku toteutus)
+                                                         (assoc-paatelty-alkamiskausi-for-hakukohde hakukohde-from-kouta haku toteutus)
                                                          (assoc-odw-kk-tasot haku koulutus)
                                                          (dissoc :_enrichedData)
                                                          (common/localize-dates)) hakukohde))


### PR DESCRIPTION
Fields containing KoodiUris are processed and their keywords are changed during indexing.
Circumvent this problem by using unprocessed data.