### PR TITLE
OY-4387 Add esitysnimi to koulutus search results

### DIFF
--- a/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
@@ -113,7 +113,7 @@
   [koulutus]
   (let [entry (-> koulutus
                   (assoc :oid (:oid koulutus))
-                  (assoc :nimi (:nimi koulutus))
+                  (assoc :nimi (get-esitysnimi koulutus))
                   (assoc :nimi_sort (common/create-sort-names (:nimi koulutus)))
                   (assoc :kielivalinta (:kielivalinta koulutus))
                   (dissoc :johtaaTutkintoon :esikatselu :modified :muokkaaja :externalId :julkinen :tila :metadata :tarjoajat :sorakuvausId :organisaatioOid :ePerusteId)
@@ -157,7 +157,6 @@
         (indexable/->index-entry oid (-> koulutus
                                          (assoc-jarjestaja-search-terms toteutukset hakutiedot)
                                          (assoc-toteutusten-tarjoajat toteutukset)
-                                         (assoc :nimi (get-esitysnimi koulutus))
                                          (create-entry))))
       (indexable/->delete-entry oid))))
 

--- a/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/koulutus_search.clj
@@ -7,7 +7,7 @@
             [kouta-indeksoija-service.indexer.indexable :as indexable]
             [kouta-indeksoija-service.indexer.kouta.common :as common]
             [kouta-indeksoija-service.indexer.kouta.oppilaitos :as oppilaitos]
-            [kouta-indeksoija-service.util.tools :refer [->distinct-vec]]))
+            [kouta-indeksoija-service.util.tools :refer [->distinct-vec get-esitysnimi]]))
 
 (def index-name "koulutus-kouta-search")
 
@@ -157,6 +157,7 @@
         (indexable/->index-entry oid (-> koulutus
                                          (assoc-jarjestaja-search-terms toteutukset hakutiedot)
                                          (assoc-toteutusten-tarjoajat toteutukset)
+                                         (assoc :nimi (get-esitysnimi koulutus))
                                          (create-entry))))
       (indexable/->delete-entry oid))))
 

--- a/test/kouta_indeksoija_service/indexer/kouta_koulutus_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_koulutus_test.clj
@@ -130,6 +130,18 @@
              nimi-fi (get-in koulutus [:nimi :fi])]
          (is (= nimi-fi "Autoalan perustutkinto 0 fi (voimaantulo 6.6.2025)")))))))
 
+(deftest index-amm-tutkinnon-osa-koulutus-search-with-eperuste-not-yet-voimassa
+  (fixture/with-mocked-indexing
+    (testing "Indexer should index esitysnimi as nimi for koulutus-search if it is defined, relevant for future eperusteet"
+      (with-redefs [kouta-indeksoija-service.indexer.tools.koodisto/koulutusalat-taso1 mock-koulutusalat-taso1]
+        (fixture/update-koulutus-mock koulutus-oid
+                                      :_enrichedData fixture/amm-tutkinnon-osa-enriched-data)
+        (check-all-nil)
+        (i/index-koulutukset [koulutus-oid] (. System (currentTimeMillis)))
+        (let [koulutus (get-doc koulutus-search/index-name koulutus-oid)
+              nimi-fi (get-in koulutus [:nimi :fi])]
+          (is (= nimi-fi "Autoalan perustutkinto 0 fi (voimaantulo 6.6.2025)")))))))
+
 (deftest eperuste-data-enrichment
   (fixture/with-mocked-indexing
     (testing "Indexer should enrich eperuste data to metadata"


### PR DESCRIPTION
Previously only koulutus index used the existing esitysnimi (display name) field in case it was available. Add the same extended field to koulutus-search to display extra information in search result titles.