### PR TITLE
Oy 4464 Lukiohakukohteen A-kielistä ja B-kielistä siirtyy vain pilkku Opintopolun puolelle

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,11 @@ Jos törmäät seuraavaan virheeseen esimerkiksi testejä ajaessasi:
 
 Aja seuraava loitsu (mahdollisesti joutuu myös ajamaan `aws configure` ennen tätä):
 
+AWS CLI v1:
 `aws ecr get-login --no-include-email --region eu-west-1 --profile oph-utility`
+
+AWS CLI v2:
+`aws ecr get-login-password --region eu-west-1 --profile oph-utility | docker login --username AWS --password-stdin 190073735177.dkr.ecr.eu-west-1.amazonaws.com`
 
 ## 6. Lisätietoa
 

--- a/README.md
+++ b/README.md
@@ -254,10 +254,17 @@ Jos törmäät seuraavaan virheeseen esimerkiksi testejä ajaessasi:
 Aja seuraava loitsu (mahdollisesti joutuu myös ajamaan `aws configure` ennen tätä):
 
 AWS CLI v1:
+
 `aws ecr get-login --no-include-email --region eu-west-1 --profile oph-utility`
 
 AWS CLI v2:
+
 `aws ecr get-login-password --region eu-west-1 --profile oph-utility | docker login --username AWS --password-stdin 190073735177.dkr.ecr.eu-west-1.amazonaws.com`
+
+ARM-arkkitehtuurilla elasticsearchin docker kontti buildattava itse.
+
+`elastic/create-bundles.sh`
+`elastic/build.sh`
 
 ## 6. Lisätietoa
 

--- a/src/kouta_indeksoija_service/api.clj
+++ b/src/kouta_indeksoija_service/api.clj
@@ -438,7 +438,7 @@
 
        (POST "/koodistot" [:as request]
          :summary "Indeksoi (filtereissä käytettävien) koodistojen uusimmat versiot."
-         :query-params [{koodistot :- String "maakunta,kunta,oppilaitoksenopetuskieli,kansallinenkoulutusluokitus2016koulutusalataso1,kansallinenkoulutusluokitus2016koulutusalataso2,koulutustyyppi,opetuspaikkakk,hakutapa,valintatapajono,pohjakoulutusvaatimuskonfo,lukiopainotukset,lukiolinjaterityinenkoulutustehtava,osaamisala,kielivalikoima,opetusaikakk,sosiaalinenmedia"}]
+         :query-params [{koodistot :- String "maakunta,kunta,oppilaitoksenopetuskieli,kansallinenkoulutusluokitus2016koulutusalataso1,kansallinenkoulutusluokitus2016koulutusalataso2,koulutustyyppi,opetuspaikkakk,hakutapa,valintatapajono,pohjakoulutusvaatimuskonfo,lukiopainotukset,lukiolinjaterityinenkoulutustehtava,osaamisala,kielivalikoima,opetusaikakk,sosiaalinenmedia,painotettavatoppiaineetlukiossa"}]
          (with-access-logging request (ok {:result (indexer/index-koodistot (comma-separated-string->vec koodistot))})))
 
        (POST "/lokalisointi" [:as request]

--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -291,7 +291,8 @@
   [hakukohde]
   (if
    (not (nil? (get-in hakukohde [:metadata :hakukohteenLinja :painotetutArvosanat])))
-    (update-in hakukohde [:metadata :hakukohteenLinja :painotetutArvosanat] complete-painotetut-lukioarvosanat-kaikki)
+    (update-in hakukohde [:metadata :hakukohteenLinja :painotetutArvosanatOppiaineittain]
+               complete-painotetut-lukioarvosanat-kaikki)
     hakukohde))
 
 (defn- odw-alempi-kk-aste?

--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -254,7 +254,8 @@
 
 (defn- replace-with-koodisto-oppiaineet
   [koodiuri]
-  (let [koodisto-oppiaineet (filter #(str/starts-with? % (get-in koodiuri [:koodiUrit :oppiaine]))
+  (let [koodisto-oppiaineet (filter #(and (str/starts-with? % (get-in koodiuri [:koodiUrit :oppiaine]))
+                                          (not= % (get-in koodiuri [:koodiUrit :oppiaine])))
                                     (koodisto-tools/painotettavatoppiaineetlukiossa-koodiurit))
         painokerroin (get koodiuri :painokerroin)]
     (map #(assoc {} :koodiUrit {:oppiaine %}, :painokerroin painokerroin) koodisto-oppiaineet)))

--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -278,7 +278,7 @@
   (flatten
    (seq (s/difference (set koodiurit-koodisto) (set koodiurit-with-painokertoimet)))))
 
-(defn- complete-painotetut-lukioarvosanat-kaikki
+(defn complete-painotetut-lukioarvosanat-kaikki
   [koodiurit]
   (let [koodiurit-to-complete (get-koodiurit-to-complete koodiurit)
         koodiurit-koodisto (get-koodisto-koodiurit koodiurit koodiurit-to-complete)
@@ -289,9 +289,9 @@
 
 (defn- complete-painotetut-lukioarvosanat-if-exists
   [hakukohde]
-  (if-let [painotetut-oppiaineet (get-in hakukohde [:metadata :hakukohteenLinja :painotetutArvosanat])]
+  (if-let [painotetut-arvosanat (get-in hakukohde [:metadata :hakukohteenLinja :painotetutArvosanat])]
     (assoc-in hakukohde [:metadata :hakukohteenLinja :painotetutArvosanatOppiaineittain]
-               (complete-painotetut-lukioarvosanat-kaikki painotetut-oppiaineet))
+               (complete-painotetut-lukioarvosanat-kaikki painotetut-arvosanat))
     hakukohde))
 
 (defn- odw-alempi-kk-aste?

--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -289,10 +289,9 @@
 
 (defn- complete-painotetut-lukioarvosanat-if-exists
   [hakukohde]
-  (if
-   (not (nil? (get-in hakukohde [:metadata :hakukohteenLinja :painotetutArvosanat])))
-    (update-in hakukohde [:metadata :hakukohteenLinja :painotetutArvosanatOppiaineittain]
-               complete-painotetut-lukioarvosanat-kaikki)
+  (if-let [painotetut-oppiaineet (get-in hakukohde [:metadata :hakukohteenLinja :painotetutArvosanat])]
+    (assoc-in hakukohde [:metadata :hakukohteenLinja :painotetutArvosanatOppiaineittain]
+               (complete-painotetut-lukioarvosanat-kaikki painotetut-oppiaineet))
     hakukohde))
 
 (defn- odw-alempi-kk-aste?

--- a/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/hakukohde.clj
@@ -254,9 +254,10 @@
 
 (defn- replace-with-koodisto-oppiaineet
   [koodiuri]
-  (let [koodisto-oppiaineet (filter #(and (str/starts-with? % (get-in koodiuri [:koodiUrit :oppiaine]))
-                                          (not= % (get-in koodiuri [:koodiUrit :oppiaine])))
-                                    (koodisto-tools/painotettavatoppiaineetlukiossa-koodiurit))
+  (let [koodisto-oppiaineet (filter
+                              #(and (str/starts-with? % (remove-uri-version (get-in koodiuri [:koodiUrit :oppiaine])))
+                                    (not= % (get-in koodiuri [:koodiUrit :oppiaine])))
+                              (koodisto-tools/painotettavatoppiaineetlukiossa-koodiurit))
         painokerroin (get koodiuri :painokerroin)]
     (map #(assoc {} :koodiUrit {:oppiaine %}, :painokerroin painokerroin) koodisto-oppiaineet)))
 

--- a/src/kouta_indeksoija_service/indexer/kouta/toteutus.clj
+++ b/src/kouta_indeksoija_service/indexer/kouta/toteutus.clj
@@ -8,7 +8,8 @@
             [kouta-indeksoija-service.indexer.tools.tyyppi :refer [remove-uri-version]]
             [kouta-indeksoija-service.util.tools :refer [->distinct-vec get-esitysnimi get-oids]]
             [kouta-indeksoija-service.indexer.tools.koulutustyyppi :refer [assoc-koulutustyyppi-path]]
-            [kouta-indeksoija-service.indexer.tools.general :refer [not-poistettu?]]))
+            [kouta-indeksoija-service.indexer.tools.general :refer [not-poistettu?]]
+            [kouta-indeksoija-service.indexer.kouta.hakukohde :refer [complete-painotetut-lukioarvosanat-kaikki]]))
 
 (def index-name "toteutus-kouta")
 
@@ -36,6 +37,13 @@
         valintakoe-ids (:valintakoeIds ht-hakukohde)]
     (assoc ht-hakukohde :hasValintaperustekuvausData (boolean (or (seq kynnysehto) (seq valintakoe-ids))))))
 
+(defn- complete-painotetut-lukioarvosanat-if-exists
+  [hakukohde]
+  (if-let [painotetut-arvosanat (get-in hakukohde [:hakukohteenLinja :painotetutArvosanat])]
+    (assoc-in hakukohde [:hakukohteenLinja :painotetutArvosanatOppiaineittain]
+              (complete-painotetut-lukioarvosanat-kaikki painotetut-arvosanat))
+    hakukohde))
+
 (defn- create-hakukohteiden-hakutiedot
   [ht-haku]
   (for [ht-hakukohde (:hakukohteet ht-haku)]
@@ -56,6 +64,7 @@
                       :hasValintaperustekuvausData
                       :jarjestaaUrheilijanAmmKoulutusta
                       :metadata])
+        (complete-painotetut-lukioarvosanat-if-exists)
         (merge (determine-correct-aikataulu-and-hakulomake ht-haku ht-hakukohde))
         (common/decorate-koodi-uris)
         (common/assoc-jarjestyspaikka)

--- a/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
@@ -62,7 +62,7 @@
         (fixture/update-toteutus-mock toteutus-oid :tila "tallennettu" :metadata fixture/lk-toteutus-metadata)
         (fixture/update-hakukohde-mock hakukohde-oid
                                        :metadata {:hakukohteenLinja           {:painotetutArvosanat     [{:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1it#1"}, :painokerroin 7},
-                                                                                                         {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1"}, :painokerroin 7},
+                                                                                                         {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1"}, :painokerroin 2},
                                                                                                          {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1en#1"}, :painokerroin 99},
                                                                                                          {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_b2en#1"}, :painokerroin 5}]
                                                                                :alinHyvaksyttyKeskiarvo 6.5 :lisatietoa {:fi "fi-str", :sv "sv-str"}}
@@ -76,7 +76,7 @@
                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1",
                                                               :nimi
                                                               {:fi "painotettavatoppiaineetlukiossa_a1 nimi fi",
-                                                               :sv "painotettavatoppiaineetlukiossa_a1 nimi sv"}}}, :painokerroin 7}
+                                                               :sv "painotettavatoppiaineetlukiossa_a1 nimi sv"}}}, :painokerroin 2}
                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1en#1",
                                                               :nimi {:fi "painotettavatoppiaineetlukiossa_a1en#1 nimi fi",
                                                                      :sv "painotettavatoppiaineetlukiossa_a1en#1 nimi sv"}}}, :painokerroin 99}

--- a/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
@@ -70,7 +70,11 @@
                                                   :koulutuksenAlkamiskausi    {:alkamiskausityyppi "henkilokohtainen suunnitelma"}})
         (i/index-hakukohteet [hakukohde-oid] (. System (currentTimeMillis)))
         (let [hakukohde (get-doc hakukohde/index-name hakukohde-oid)]
-          (is (= {:painotetutArvosanat     [{:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_b2en#1",
+          (is (= {:painotetutArvosanat [{:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1it#1"}, :painokerroin 7},
+                                        {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1"}, :painokerroin 2},
+                                        {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1en#1"}, :painokerroin 99},
+                                        {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_b2en#1"}, :painokerroin 5}]
+                  :painotetutArvosanatOppiaineittain     [{:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_b2en#1",
                                                                  :nimi     {:fi "painotettavatoppiaineetlukiossa_b2en#1 nimi fi",
                                                                             :sv "painotettavatoppiaineetlukiossa_b2en#1 nimi sv"}}}, :painokerroin 5}
                                             {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1lv#1",
@@ -145,7 +149,9 @@
                                                   :koulutuksenAlkamiskausi    {:alkamiskausityyppi "henkilokohtainen suunnitelma"}})
         (i/index-hakukohteet [hakukohde-oid] (. System (currentTimeMillis)))
         (let [hakukohde (get-doc hakukohde/index-name hakukohde-oid)]
-          (is (= {:painotetutArvosanat     [{:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_b2en#1",
+          (is (= {:painotetutArvosanat [{:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1it#1"}, :painokerroin 666},
+                                        {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_b2en#1"}, :painokerroin 999}]
+                  :painotetutArvosanatOppiaineittain     [{:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_b2en#1",
                                                                  :nimi     {:fi "painotettavatoppiaineetlukiossa_b2en#1 nimi fi",
                                                                             :sv "painotettavatoppiaineetlukiossa_b2en#1 nimi sv"}}}, :painokerroin 999}
                                             {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1it#1",

--- a/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
@@ -62,7 +62,7 @@
         (fixture/update-toteutus-mock toteutus-oid :tila "tallennettu" :metadata fixture/lk-toteutus-metadata)
         (fixture/update-hakukohde-mock hakukohde-oid
                                        :metadata {:hakukohteenLinja           {:painotetutArvosanat     [{:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1it#1"}, :painokerroin 7},
-                                                                                                         {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1"}, :painokerroin 2},
+                                                                                                         {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1#1"}, :painokerroin 2},
                                                                                                          {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1en#1"}, :painokerroin 99},
                                                                                                          {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_b2en#1"}, :painokerroin 5}]
                                                                                :alinHyvaksyttyKeskiarvo 6.5 :lisatietoa {:fi "fi-str", :sv "sv-str"}}
@@ -73,10 +73,10 @@
           (is (= {:painotetutArvosanat [{:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1it#1",
                                                              :nimi {:fi "painotettavatoppiaineetlukiossa_a1it#1 nimi fi",
                                                                     :sv "painotettavatoppiaineetlukiossa_a1it#1 nimi sv"}}}, :painokerroin 7}
-                                         {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1",
+                                         {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1#1",
                                                               :nimi
-                                                              {:fi "painotettavatoppiaineetlukiossa_a1 nimi fi",
-                                                               :sv "painotettavatoppiaineetlukiossa_a1 nimi sv"}}}, :painokerroin 2}
+                                                              {:fi "painotettavatoppiaineetlukiossa_a1#1 nimi fi",
+                                                               :sv "painotettavatoppiaineetlukiossa_a1#1 nimi sv"}}}, :painokerroin 2}
                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1en#1",
                                                               :nimi {:fi "painotettavatoppiaineetlukiossa_a1en#1 nimi fi",
                                                                      :sv "painotettavatoppiaineetlukiossa_a1en#1 nimi sv"}}}, :painokerroin 99}

--- a/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
@@ -51,7 +51,7 @@
                                                 :koulutuksenAlkamiskausi {:alkamiskausityyppi "henkilokohtainen suunnitelma"}})
      (i/index-hakukohteet [hakukohde-oid] (. System (currentTimeMillis)))
      (let [hakukohde (get-doc hakukohde/index-name hakukohde-oid)]
-       (is (= {:painotetutArvosanat [] :alinHyvaksyttyKeskiarvo 6.5 :lisatietoa {:fi "fi-str", :sv "sv-str"}} (get-in hakukohde [:metadata :hakukohteenLinja])))))))
+       (is (= {:painotetutArvosanat [] :painotetutArvosanatOppiaineittain [] :alinHyvaksyttyKeskiarvo 6.5 :lisatietoa {:fi "fi-str", :sv "sv-str"}} (get-in hakukohde [:metadata :hakukohteenLinja])))))))
 
 (deftest index-lukio-hakukohde-painotetut-arvosanat-kaikki-test
   (fixture/with-mocked-indexing

--- a/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
+++ b/test/kouta_indeksoija_service/indexer/kouta_hakukohde_test.clj
@@ -62,7 +62,7 @@
         (fixture/update-toteutus-mock toteutus-oid :tila "tallennettu" :metadata fixture/lk-toteutus-metadata)
         (fixture/update-hakukohde-mock hakukohde-oid
                                        :metadata {:hakukohteenLinja           {:painotetutArvosanat     [{:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1it#1"}, :painokerroin 7},
-                                                                                                         {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1"}, :painokerroin 2},
+                                                                                                         {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1"}, :painokerroin 7},
                                                                                                          {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1en#1"}, :painokerroin 99},
                                                                                                          {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_b2en#1"}, :painokerroin 5}]
                                                                                :alinHyvaksyttyKeskiarvo 6.5 :lisatietoa {:fi "fi-str", :sv "sv-str"}}
@@ -70,67 +70,76 @@
                                                   :koulutuksenAlkamiskausi    {:alkamiskausityyppi "henkilokohtainen suunnitelma"}})
         (i/index-hakukohteet [hakukohde-oid] (. System (currentTimeMillis)))
         (let [hakukohde (get-doc hakukohde/index-name hakukohde-oid)]
-          (is (= {:painotetutArvosanat [{:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1it#1"}, :painokerroin 7},
-                                        {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1"}, :painokerroin 2},
-                                        {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1en#1"}, :painokerroin 99},
-                                        {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_b2en#1"}, :painokerroin 5}]
+          (is (= {:painotetutArvosanat [{:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1it#1",
+                                                             :nimi {:fi "painotettavatoppiaineetlukiossa_a1it#1 nimi fi",
+                                                                    :sv "painotettavatoppiaineetlukiossa_a1it#1 nimi sv"}}}, :painokerroin 7}
+                                         {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1",
+                                                              :nimi
+                                                              {:fi "painotettavatoppiaineetlukiossa_a1 nimi fi",
+                                                               :sv "painotettavatoppiaineetlukiossa_a1 nimi sv"}}}, :painokerroin 7}
+                                         {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1en#1",
+                                                              :nimi {:fi "painotettavatoppiaineetlukiossa_a1en#1 nimi fi",
+                                                                     :sv "painotettavatoppiaineetlukiossa_a1en#1 nimi sv"}}}, :painokerroin 99}
+                                         {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_b2en#1",
+                                                              :nimi {:fi "painotettavatoppiaineetlukiossa_b2en#1 nimi fi",
+                                                                     :sv "painotettavatoppiaineetlukiossa_b2en#1 nimi sv"}}}, :painokerroin 5}]
                   :painotetutArvosanatOppiaineittain     [{:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_b2en#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_b2en#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_b2en#1 nimi sv"}}}, :painokerroin 5}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1lv#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1lv#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1lv#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1vk#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1vk#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1vk#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1et#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1et#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1et#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1de#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1de#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1de#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1ru#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1ru#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1ru#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1fr#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1fr#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1fr#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1ja#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1ja#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1ja#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1lt#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1lt#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1lt#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1en#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1en#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1en#1 nimi sv"}}}, :painokerroin 99}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1zh#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1zh#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1zh#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1pt#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1pt#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1pt#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1la#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1la#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1la#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1el#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1el#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1el#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1it#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1it#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1it#1 nimi sv"}}}, :painokerroin 7}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1sv#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1sv#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1sv#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1es#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1es#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1es#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1se#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1se#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1se#1 nimi sv"}}}, :painokerroin 2}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1fi#1",
-                                                                 :nimi     {:fi "painotettavatoppiaineetlukiossa_a1fi#1 nimi fi",
-                                                                            :sv "painotettavatoppiaineetlukiossa_a1fi#1 nimi sv"}}}, :painokerroin 2}]
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_b2en#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_b2en#1 nimi sv"}}}, :painokerroin 5}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1lv#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1lv#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1lv#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1vk#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1vk#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1vk#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1et#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1et#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1et#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1de#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1de#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1de#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1ru#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1ru#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1ru#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1fr#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1fr#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1fr#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1ja#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1ja#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1ja#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1lt#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1lt#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1lt#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1en#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1en#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1en#1 nimi sv"}}}, :painokerroin 99}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1zh#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1zh#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1zh#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1pt#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1pt#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1pt#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1la#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1la#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1la#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1el#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1el#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1el#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1it#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1it#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1it#1 nimi sv"}}}, :painokerroin 7}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1sv#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1sv#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1sv#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1es#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1es#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1es#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1se#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1se#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1se#1 nimi sv"}}}, :painokerroin 2}
+                                                          {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1fi#1",
+                                                                               :nimi     {:fi "painotettavatoppiaineetlukiossa_a1fi#1 nimi fi",
+                                                                                          :sv "painotettavatoppiaineetlukiossa_a1fi#1 nimi sv"}}}, :painokerroin 2}]
                   :alinHyvaksyttyKeskiarvo 6.5 :lisatietoa {:fi "fi-str", :sv "sv-str"}}
                  (get-in hakukohde [:metadata :hakukohteenLinja]))))))))
 
@@ -149,12 +158,16 @@
                                                   :koulutuksenAlkamiskausi    {:alkamiskausityyppi "henkilokohtainen suunnitelma"}})
         (i/index-hakukohteet [hakukohde-oid] (. System (currentTimeMillis)))
         (let [hakukohde (get-doc hakukohde/index-name hakukohde-oid)]
-          (is (= {:painotetutArvosanat [{:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_a1it#1"}, :painokerroin 666},
-                                        {:koodiUrit {:oppiaine "painotettavatoppiaineetlukiossa_b2en#1"}, :painokerroin 999}]
-                  :painotetutArvosanatOppiaineittain     [{:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_b2en#1",
+          (is (= {:painotetutArvosanat                  [{:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1it#1",
+                                                                              :nimi {:fi "painotettavatoppiaineetlukiossa_a1it#1 nimi fi",
+                                                                                     :sv "painotettavatoppiaineetlukiossa_a1it#1 nimi sv"}}}, :painokerroin 666}
+                                                         {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_b2en#1",
+                                                                              :nimi {:fi "painotettavatoppiaineetlukiossa_b2en#1 nimi fi",
+                                                                                     :sv "painotettavatoppiaineetlukiossa_b2en#1 nimi sv"}}}, :painokerroin 999}]
+                  :painotetutArvosanatOppiaineittain  [{:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_b2en#1",
                                                                  :nimi     {:fi "painotettavatoppiaineetlukiossa_b2en#1 nimi fi",
                                                                             :sv "painotettavatoppiaineetlukiossa_b2en#1 nimi sv"}}}, :painokerroin 999}
-                                            {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1it#1",
+                                                       {:koodit {:oppiaine {:koodiUri "painotettavatoppiaineetlukiossa_a1it#1",
                                                                  :nimi     {:fi "painotettavatoppiaineetlukiossa_a1it#1 nimi fi",
                                                                             :sv "painotettavatoppiaineetlukiossa_a1it#1 nimi sv"}}}, :painokerroin 666}]
                   :alinHyvaksyttyKeskiarvo 6.5 :lisatietoa {:fi "fi-str", :sv "sv-str"}}

--- a/test/resources/koodisto/painotettavatoppiaineetlukiossa.json
+++ b/test/resources/koodisto/painotettavatoppiaineetlukiossa.json
@@ -2565,6 +2565,114 @@
     ]
   },
   {
+    "koodiUri": "painotettavatoppiaineetlukiossa_a2",
+    "resourceUri": "https://virkailija.opintopolku.fi/koodisto-service/rest/codeelement/painotettavatoppiaineetlukiossa_a2",
+    "version": 0,
+    "versio": 1,
+    "koodisto": {
+      "koodistoUri": "painotettavatoppiaineetlukiossa",
+      "organisaatioOid": "1.2.246.562.10.00000000001",
+      "koodistoVersios": [
+        1
+      ]
+    },
+    "koodiArvo": "a2",
+    "paivitysPvm": "2023-10-09",
+    "paivittajaOid": "1.2.246.562.24.67130825240",
+    "voimassaAlkuPvm": "2023-10-09",
+    "voimassaLoppuPvm": null,
+    "tila": "LUONNOS",
+    "metadata": [
+      {
+        "nimi": "A2 (Alla)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "SV"
+      },
+      {
+        "nimi": "A2 (All)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "EN"
+      },
+      {
+        "nimi": "A2 (Kaikki)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "FI"
+      }
+    ]
+  },
+  {
+    "koodiUri": "painotettavatoppiaineetlukiossa_b1",
+    "resourceUri": "https://virkailija.opintopolku.fi/koodisto-service/rest/codeelement/painotettavatoppiaineetlukiossa_b1",
+    "version": 0,
+    "versio": 1,
+    "koodisto": {
+      "koodistoUri": "painotettavatoppiaineetlukiossa",
+      "organisaatioOid": "1.2.246.562.10.00000000001",
+      "koodistoVersios": [
+        1
+      ]
+    },
+    "koodiArvo": "b1",
+    "paivitysPvm": "2023-10-09",
+    "paivittajaOid": "1.2.246.562.24.67130825240",
+    "voimassaAlkuPvm": "2023-10-09",
+    "voimassaLoppuPvm": null,
+    "tila": "LUONNOS",
+    "metadata": [
+      {
+        "nimi": "B1 (Alla)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "SV"
+      },
+      {
+        "nimi": "B1 (All)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "EN"
+      },
+      {
+        "nimi": "B1 (Kaikki)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "FI"
+      }
+    ]
+  },
+  {
     "koodiUri": "painotettavatoppiaineetlukiossa_fy",
     "resourceUri": "https://virkailija.opintopolku.fi/koodisto-service/rest/codeelement/painotettavatoppiaineetlukiossa_fy",
     "version": 0,
@@ -2599,6 +2707,60 @@
         "nimi": "Fysik",
         "kuvaus": "Fysik",
         "lyhytNimi": "Fysik",
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "SV"
+      }
+    ]
+  },
+  {
+    "koodiUri": "painotettavatoppiaineetlukiossa_a1",
+    "resourceUri": "https://virkailija.opintopolku.fi/koodisto-service/rest/codeelement/painotettavatoppiaineetlukiossa_a1",
+    "version": 0,
+    "versio": 1,
+    "koodisto": {
+      "koodistoUri": "painotettavatoppiaineetlukiossa",
+      "organisaatioOid": "1.2.246.562.10.00000000001",
+      "koodistoVersios": [
+        1
+      ]
+    },
+    "koodiArvo": "a1",
+    "paivitysPvm": "2023-10-09",
+    "paivittajaOid": "1.2.246.562.24.67130825240",
+    "voimassaAlkuPvm": "2023-10-09",
+    "voimassaLoppuPvm": null,
+    "tila": "LUONNOS",
+    "metadata": [
+      {
+        "nimi": "A1 (Kaikki)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "FI"
+      },
+      {
+        "nimi": "A1 (All)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "EN"
+      },
+      {
+        "nimi": "A1 (Alla)",
+        "kuvaus": null,
         "kayttoohje": null,
         "kasite": null,
         "sisaltaaMerkityksen": null,
@@ -3510,6 +3672,60 @@
     ]
   },
   {
+    "koodiUri": "painotettavatoppiaineetlukiossa_b2",
+    "resourceUri": "https://virkailija.opintopolku.fi/koodisto-service/rest/codeelement/painotettavatoppiaineetlukiossa_b2",
+    "version": 0,
+    "versio": 1,
+    "koodisto": {
+      "koodistoUri": "painotettavatoppiaineetlukiossa",
+      "organisaatioOid": "1.2.246.562.10.00000000001",
+      "koodistoVersios": [
+        1
+      ]
+    },
+    "koodiArvo": "b2",
+    "paivitysPvm": "2023-10-09",
+    "paivittajaOid": "1.2.246.562.24.67130825240",
+    "voimassaAlkuPvm": "2023-10-09",
+    "voimassaLoppuPvm": null,
+    "tila": "LUONNOS",
+    "metadata": [
+      {
+        "nimi": "B2 (Kaikki)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "FI"
+      },
+      {
+        "nimi": "B2 (All)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "EN"
+      },
+      {
+        "nimi": "B2 (Alla)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "SV"
+      }
+    ]
+  },
+  {
     "koodiUri": "painotettavatoppiaineetlukiossa_b1ja",
     "resourceUri": "https://virkailija.opintopolku.fi/koodisto-service/rest/codeelement/painotettavatoppiaineetlukiossa_b1ja",
     "version": 0,
@@ -3544,6 +3760,60 @@
         "nimi": "B1 japanska",
         "kuvaus": "B1 japanska",
         "lyhytNimi": "B1 japanska",
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "SV"
+      }
+    ]
+  },
+  {
+    "koodiUri": "painotettavatoppiaineetlukiossa_b3",
+    "resourceUri": "https://virkailija.opintopolku.fi/koodisto-service/rest/codeelement/painotettavatoppiaineetlukiossa_b3",
+    "version": 0,
+    "versio": 1,
+    "koodisto": {
+      "koodistoUri": "painotettavatoppiaineetlukiossa",
+      "organisaatioOid": "1.2.246.562.10.00000000001",
+      "koodistoVersios": [
+        1
+      ]
+    },
+    "koodiArvo": "b3",
+    "paivitysPvm": "2023-10-09",
+    "paivittajaOid": "1.2.246.562.24.67130825240",
+    "voimassaAlkuPvm": "2023-10-09",
+    "voimassaLoppuPvm": null,
+    "tila": "LUONNOS",
+    "metadata": [
+      {
+        "nimi": "B3 (Kaikki)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "FI"
+      },
+      {
+        "nimi": "B3 (All)",
+        "kuvaus": null,
+        "kayttoohje": null,
+        "kasite": null,
+        "sisaltaaMerkityksen": null,
+        "eiSisallaMerkitysta": null,
+        "huomioitavaKoodi": null,
+        "sisaltaaKoodiston": null,
+        "kieli": "EN"
+      },
+      {
+        "nimi": "B3 (Alla)",
+        "kuvaus": null,
         "kayttoohje": null,
         "kasite": null,
         "sisaltaaMerkityksen": null,

--- a/test/resources/kouta/kouta-toteutus-lukio-result.json
+++ b/test/resources/kouta/kouta-toteutus-lukio-result.json
@@ -448,6 +448,7 @@
           ],
           "hakukohteenLinja": {
             "painotetutArvosanat": [],
+            "painotetutArvosanatOppiaineittain": [],
             "alinHyvaksyttyKeskiarvo": 6.5,
             "lisatietoa": {
               "fi": "fi-str",


### PR DESCRIPTION
Muutettu lukiohakukohteiden painotettavien oppiaineiden indeksointia niin, että alkuperäinen lista (joka sisältää "A1 kaikki" tyyppisiä koodeja) säilyy painotettavatArvosanat kentässä, ja avattu lista vain oppiaineista tallennetaan kenttään painotetutArvosanatOppiaineittain.