### PR TITLE
OK-376: Korjattu pistehistorian indeksointi lukio-hakukohteille

### DIFF
--- a/src/kouta_indeksoija_service/rest/kouta.clj
+++ b/src/kouta_indeksoija_service/rest/kouta.clj
@@ -85,9 +85,11 @@
     get-pistehistoria kouta-cache-time-millis kouta-cache-size))
 
 ;Käytännössä tällä löytyy tietoa vain toisen asteen hakukohteille
+;HUOM! Hakukohde voi olla koutan hakukohde tai hakutiedon hakukohde!
 (defn get-pistehistoria-for-hakukohde [hakukohde execution-id]
   (let [jarjestyspaikkaOid (:jarjestyspaikkaOid hakukohde)
-        lukiolinja (:hakukohteenLinja hakukohde)
+        lukiolinja (get-in hakukohde [:metadata :hakukohteenLinja]
+                           (:hakukohteenLinja hakukohde))
         lukiolinjaKoodiUri (:linja lukiolinja)
         hakukohdeKoodiUri (or (:hakukohdeKoodiUri hakukohde)
                               (when (and (some? lukiolinja)


### PR DESCRIPTION
- get-pistehistoria-for-hakukohde-funktiossa ei otettu huomioon, että "hakukohde" voi olla myös koutan hakukohde, jolla "hakukohteenLinja" on metadatan sisällä